### PR TITLE
feat(swagger): swagger docs for mcp endpoints

### DIFF
--- a/app/api/v2/schemas/base_schemas.py
+++ b/app/api/v2/schemas/base_schemas.py
@@ -18,7 +18,7 @@ class ModelConfigSchema(Schema):
     model = fields.Str(description="Model name/identifier (e.g., 'gpt-4', 'claude-3-5-sonnet')")
     temperature = fields.Float(description="Sampling temperature (0.0-1.0)")
     max_tokens = fields.Int(description="Maximum tokens to generate")
-    api_key = fields.Str(description="API key for the model provider")
+    api_key = fields.Str(description="API key for model provider. Recommended: configure server-side via DSPY_API_KEY environment variable")
     api_base = fields.Str(description="Base URL for API endpoint")
     timeout = fields.Int(description="Request timeout in seconds")
 

--- a/app/api/v2/schemas/base_schemas.py
+++ b/app/api/v2/schemas/base_schemas.py
@@ -1,0 +1,24 @@
+"""
+Base schemas for MCP plugin API documentation.
+Common schemas used across multiple endpoints.
+"""
+
+from marshmallow import Schema, fields
+
+
+class ErrorResponseSchema(Schema):
+    """Standard error response"""
+
+    error = fields.Str(required=True, description="Error message")
+
+
+class ModelConfigSchema(Schema):
+    """LLM model configuration"""
+
+    model = fields.Str(description="Model name/identifier (e.g., 'gpt-4', 'claude-3-5-sonnet')")
+    temperature = fields.Float(description="Sampling temperature (0.0-1.0)")
+    max_tokens = fields.Int(description="Maximum tokens to generate")
+    api_key = fields.Str(description="API key for the model provider")
+    api_base = fields.Str(description="Base URL for API endpoint")
+    timeout = fields.Int(description="Request timeout in seconds")
+

--- a/app/api/v2/schemas/execute_schemas.py
+++ b/app/api/v2/schemas/execute_schemas.py
@@ -1,0 +1,43 @@
+"""
+Execution schemas for MCP plugin.
+Handles AI agent execution requests and responses.
+"""
+
+from marshmallow import Schema, fields
+from plugins.mcp.app.api.v2.schemas.base_schemas import ModelConfigSchema
+
+
+class ExecuteRequestSchema(Schema):
+    """Request schema for executing AI agent tasks"""
+
+    text = fields.Str(
+        required=True,
+        description="The prompt/task to execute"
+    )
+    type = fields.Str(
+        description="Execution focus type: 'factory', 'planner', or 'server'",
+        default="factory"
+    )
+    config = fields.Nested(
+        ModelConfigSchema,
+        description="Optional model configuration overrides"
+    )
+
+
+class ExecuteResponseSchema(Schema):
+    """Response schema for execution requests"""
+
+    run_id = fields.Str(
+        required=True,
+        description="MLflow run ID for tracking execution"
+    )
+    status = fields.Str(
+        description="Execution status"
+    )
+    result = fields.Str(
+        description="Execution result or output"
+    )
+    message = fields.Str(
+        description="Status message"
+    )
+

--- a/app/api/v2/schemas/execute_schemas.py
+++ b/app/api/v2/schemas/execute_schemas.py
@@ -14,7 +14,8 @@ class ExecuteRequestSchema(Schema):
         required=True,
         description="The prompt/task to execute"
     )
-    type = fields.Str(
+    execution_type = fields.Str(
+        data_key="type",
         description="Execution focus type: 'factory', 'planner', or 'server'",
         default="factory"
     )

--- a/app/api/v2/schemas/rag_schemas.py
+++ b/app/api/v2/schemas/rag_schemas.py
@@ -1,0 +1,55 @@
+"""
+RAG (Retrieval-Augmented Generation) schemas for MCP plugin.
+Handles file upload and listing for context/knowledge documents.
+"""
+
+from marshmallow import Schema, fields
+
+
+class UploadRagResponseSchema(Schema):
+    """Response schema for RAG file upload"""
+
+    message = fields.Str(
+        required=True,
+        description="Upload status message"
+    )
+    filename = fields.Str(
+        required=True,
+        description="Uploaded filename"
+    )
+    size = fields.Int(
+        required=True,
+        description="File size in bytes"
+    )
+    path = fields.Str(
+        required=True,
+        description="Server-side file path"
+    )
+
+
+class RagFileSchema(Schema):
+    """RAG file information"""
+
+    filename = fields.Str(
+        required=True,
+        description="File name"
+    )
+    size = fields.Int(
+        required=True,
+        description="File size in bytes"
+    )
+    modified = fields.Str(
+        required=True,
+        description="Last modified timestamp (ISO 8601 format)"
+    )
+
+
+class ListRagResponseSchema(Schema):
+    """Response schema for listing RAG files"""
+
+    files = fields.List(
+        fields.Nested(RagFileSchema),
+        required=True,
+        description="List of available RAG files"
+    )
+

--- a/app/api/v2/schemas/runs_schemas.py
+++ b/app/api/v2/schemas/runs_schemas.py
@@ -86,7 +86,8 @@ class GetRunDetailRequestSchema(Schema):
 
     run_id = fields.Str(
         required=True,
-        description="MLflow run ID to retrieve details for"
+        description="MLflow run ID to retrieve details for",
+        metadata={"location": "query"},
     )
 
 

--- a/app/api/v2/schemas/runs_schemas.py
+++ b/app/api/v2/schemas/runs_schemas.py
@@ -11,11 +11,13 @@ class ListRunsRequestSchema(Schema):
 
     limit = fields.Int(
         description="Maximum number of runs to return",
-        default=100
+        default=100,
+        metadata={"location": "query"},
     )
     offset = fields.Int(
         description="Offset for pagination",
-        default=0
+        default=0,
+        metadata={"location": "query"},
     )
 
 

--- a/app/api/v2/schemas/runs_schemas.py
+++ b/app/api/v2/schemas/runs_schemas.py
@@ -1,0 +1,141 @@
+"""
+Run management schemas for MCP plugin.
+Handles listing and detailed viewing of MLflow runs.
+"""
+
+from marshmallow import Schema, fields
+
+
+class ListRunsRequestSchema(Schema):
+    """Request schema for listing runs with pagination"""
+
+    limit = fields.Int(
+        description="Maximum number of runs to return",
+        default=100
+    )
+    offset = fields.Int(
+        description="Offset for pagination",
+        default=0
+    )
+
+
+class RunRecordSchema(Schema):
+    """Basic run information for list view"""
+
+    run_id = fields.Str(
+        required=True,
+        description="MLflow run ID"
+    )
+    experiment_id = fields.Str(
+        required=True,
+        description="MLflow experiment ID"
+    )
+    status = fields.Str(
+        required=True,
+        description="Run status (RUNNING, FINISHED, FAILED, etc.)"
+    )
+    start_time = fields.Int(
+        description="Start timestamp (milliseconds since epoch)"
+    )
+    end_time = fields.Int(
+        description="End timestamp (milliseconds since epoch)"
+    )
+    run_name = fields.Str(
+        description="Run name"
+    )
+    prompt = fields.Str(
+        description="Original prompt/task"
+    )
+    stage = fields.Str(
+        description="Execution stage"
+    )
+    model = fields.Str(
+        description="Model used"
+    )
+    process_result = fields.Str(
+        description="Final result"
+    )
+
+
+class ListRunsResponseSchema(Schema):
+    """Response schema for listing runs"""
+
+    runs = fields.List(
+        fields.Nested(RunRecordSchema),
+        required=True,
+        description="List of runs"
+    )
+    total = fields.Int(
+        required=True,
+        description="Total number of runs available"
+    )
+    limit = fields.Int(
+        required=True,
+        description="Limit used for pagination"
+    )
+    offset = fields.Int(
+        required=True,
+        description="Offset used for pagination"
+    )
+
+
+class GetRunDetailRequestSchema(Schema):
+    """Request schema for getting detailed run information"""
+
+    run_id = fields.Str(
+        required=True,
+        description="MLflow run ID to retrieve details for"
+    )
+
+
+class GetRunDetailResponseSchema(Schema):
+    """Response schema for detailed run information"""
+
+    run_id = fields.Str(
+        required=True,
+        description="MLflow run ID"
+    )
+    status = fields.Str(
+        required=True,
+        description="Run status"
+    )
+    start_time = fields.Int(
+        description="Start timestamp (milliseconds since epoch)"
+    )
+    end_time = fields.Int(
+        description="End timestamp (milliseconds since epoch)"
+    )
+    run_name = fields.Str(
+        description="Run name"
+    )
+    experiment_id = fields.Str(
+        description="Experiment ID"
+    )
+    params = fields.Dict(
+        keys=fields.Str(),
+        values=fields.Str(),
+        description="Run parameters"
+    )
+    tags = fields.Dict(
+        keys=fields.Str(),
+        values=fields.Str(),
+        description="Run tags"
+    )
+    trajectory = fields.Dict(
+        keys=fields.Str(),
+        values=fields.Str(),
+        description="Full execution trajectory with thoughts, observations, and tool calls"
+    )
+    stage = fields.Str(
+        description="Execution stage"
+    )
+    reasoning = fields.Str(
+        description="Agent reasoning"
+    )
+    prompt = fields.Str(
+        description="Original prompt"
+    )
+    process_result = fields.Str(
+        description="Final processed result"
+    )
+

--- a/app/api/v2/schemas/status_schemas.py
+++ b/app/api/v2/schemas/status_schemas.py
@@ -1,0 +1,46 @@
+"""
+Status tracking schemas for MCP plugin.
+Handles run status queries and trajectory information.
+"""
+
+from marshmallow import Schema, fields
+
+
+class StatusRequestSchema(Schema):
+    """Request schema for checking execution status"""
+
+    run_id = fields.Str(
+        required=True,
+        description="MLflow run ID to check status for"
+    )
+
+
+class StatusResponseSchema(Schema):
+    """Response schema for status queries"""
+
+    run_id = fields.Str(
+        required=True,
+        description="MLflow run ID"
+    )
+    status = fields.Str(
+        required=True,
+        description="Run status (RUNNING, FINISHED, FAILED, etc.)"
+    )
+    stage = fields.Str(
+        description="Current execution stage"
+    )
+    prompt = fields.Str(
+        description="Original prompt/task"
+    )
+    reasoning = fields.Str(
+        description="Agent reasoning or decision-making process"
+    )
+    process_result = fields.Str(
+        description="Final processed result"
+    )
+    trajectory = fields.Dict(
+        keys=fields.Str(),
+        values=fields.Str(),
+        description="Execution trajectory with thoughts, observations, and tool calls"
+    )
+

--- a/app/api/v2/schemas/status_schemas.py
+++ b/app/api/v2/schemas/status_schemas.py
@@ -11,7 +11,8 @@ class StatusRequestSchema(Schema):
 
     run_id = fields.Str(
         required=True,
-        description="MLflow run ID to check status for"
+        description="MLflow run ID to check status for",
+        metadata={"location": "query"},
     )
 
 

--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -59,6 +59,7 @@ class McpAPI:
         summary="Get execution status",
         description="Retrieve the current status, reasoning trajectory, and results of a running or completed execution by run ID.",
     )
+    @request_schema(StatusRequestSchema)
     @response_schema(StatusResponseSchema, 200)
     @response_schema(ErrorResponseSchema, 400)
     @response_schema(ErrorResponseSchema, 500)

--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -8,11 +8,16 @@ from pathlib import Path
 from datetime import datetime
 
 # Import API schemas
-from plugins.mcp.app.api.v2.schemas.base_schemas import *
-from plugins.mcp.app.api.v2.schemas.execute_schemas import *
-from plugins.mcp.app.api.v2.schemas.status_schemas import *
-from plugins.mcp.app.api.v2.schemas.rag_schemas import *
-from plugins.mcp.app.api.v2.schemas.runs_schemas import *
+from plugins.mcp.app.api.v2.schemas.base_schemas import ErrorResponseSchema
+from plugins.mcp.app.api.v2.schemas.execute_schemas import ExecuteRequestSchema, ExecuteResponseSchema
+from plugins.mcp.app.api.v2.schemas.status_schemas import StatusRequestSchema, StatusResponseSchema
+from plugins.mcp.app.api.v2.schemas.rag_schemas import UploadRagResponseSchema, ListRagResponseSchema
+from plugins.mcp.app.api.v2.schemas.runs_schemas import (
+    ListRunsRequestSchema,
+    ListRunsResponseSchema,
+    GetRunDetailRequestSchema,
+    GetRunDetailResponseSchema
+)
 
 class McpAPI:
 

--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -1,5 +1,5 @@
 from aiohttp import web
-from aiohttp_apispec import docs, request_schema, response_schema
+from aiohttp_apispec import docs, request_schema, response_schema, querystring_schema
 import logging
 import mlflow
 import os
@@ -64,7 +64,7 @@ class McpAPI:
         summary="Get execution status",
         description="Retrieve the current status, reasoning trajectory, and results of a running or completed execution by run ID.",
     )
-    @request_schema(StatusRequestSchema)
+    @querystring_schema(StatusRequestSchema)
     @response_schema(StatusResponseSchema, 200)
     @response_schema(ErrorResponseSchema, 400)
     @response_schema(ErrorResponseSchema, 500)
@@ -184,7 +184,7 @@ class McpAPI:
         summary="List execution history",
         description="Browse all historical ability factory and operation planner executions with pagination. Returns run metadata, prompts, and results.",
     )
-    @request_schema(ListRunsRequestSchema)
+    @querystring_schema(ListRunsRequestSchema)
     @response_schema(ListRunsResponseSchema, 200)
     @response_schema(ErrorResponseSchema, 500)
     async def list_runs(self, request):
@@ -248,7 +248,7 @@ class McpAPI:
         summary="Get detailed run information",
         description="Get comprehensive details for a specific execution including full LLM reasoning trajectory, tool calls, parameters, and results.",
     )
-    @request_schema(GetRunDetailRequestSchema)
+    @querystring_schema(GetRunDetailRequestSchema)
     @response_schema(GetRunDetailResponseSchema, 200)
     @response_schema(ErrorResponseSchema, 400)
     @response_schema(ErrorResponseSchema, 500)

--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -243,6 +243,7 @@ class McpAPI:
         summary="Get detailed run information",
         description="Get comprehensive details for a specific execution including full LLM reasoning trajectory, tool calls, parameters, and results.",
     )
+    @request_schema(GetRunDetailRequestSchema)
     @response_schema(GetRunDetailResponseSchema, 200)
     @response_schema(ErrorResponseSchema, 400)
     @response_schema(ErrorResponseSchema, 500)

--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -178,6 +178,7 @@ class McpAPI:
         summary="List execution history",
         description="Browse all historical ability factory and operation planner executions with pagination. Returns run metadata, prompts, and results.",
     )
+    @request_schema(ListRunsRequestSchema)
     @response_schema(ListRunsResponseSchema, 200)
     @response_schema(ErrorResponseSchema, 500)
     async def list_runs(self, request):

--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -23,9 +23,9 @@ class McpAPI:
         self.log.info("[MCP] Initialized McpAPI")
 
     @docs(
-        tags=["MCP / Execution"],
-        summary="Execute AI agent task",
-        description="Execute a task using the MCP AI agent. Supports factory (ability generation), planner, and server execution modes.",
+        tags=["MCP / Ability Factory"],
+        summary="Execute ability generation or operation planning",
+        description="Generate Caldera abilities or plan operations using LLM. Supports 'factory' (ability generation), 'planner' (operation planning), and RAG-enhanced modes.",
     )
     @request_schema(ExecuteRequestSchema)
     @response_schema(ExecuteResponseSchema, 200)
@@ -55,9 +55,9 @@ class McpAPI:
             return web.json_response({"error": str(e)}, status=500)
 
     @docs(
-        tags=["MCP / Status"],
+        tags=["MCP / Execution Status"],
         summary="Get execution status",
-        description="Retrieve the current status and trajectory of a running or completed MCP execution by run ID.",
+        description="Retrieve the current status, reasoning trajectory, and results of a running or completed execution by run ID.",
     )
     @response_schema(StatusResponseSchema, 200)
     @response_schema(ErrorResponseSchema, 400)
@@ -94,9 +94,9 @@ class McpAPI:
             return web.json_response({"error": str(e)}, status=500)
 
     @docs(
-        tags=["MCP / RAG"],
-        summary="Upload RAG knowledge file",
-        description="Upload a JSON file containing context/knowledge for Retrieval-Augmented Generation. Multipart form-data with 'file' field.",
+        tags=["MCP / CTI Knowledge Base"],
+        summary="Upload threat intelligence file",
+        description="Upload a STIX JSON file containing Cyber Threat Intelligence for RAG-enhanced ability generation. Multipart form-data with 'file' field.",
     )
     @response_schema(UploadRagResponseSchema, 200)
     @response_schema(ErrorResponseSchema, 400)
@@ -147,9 +147,9 @@ class McpAPI:
             return web.json_response({"error": str(e)}, status=500)
 
     @docs(
-        tags=["MCP / RAG"],
-        summary="List RAG knowledge files",
-        description="Retrieve a list of all uploaded RAG knowledge files with metadata.",
+        tags=["MCP / CTI Knowledge Base"],
+        summary="List threat intelligence files",
+        description="Retrieve a list of all uploaded STIX CTI files with metadata (filename, size, last modified).",
     )
     @response_schema(ListRagResponseSchema, 200)
     @response_schema(ErrorResponseSchema, 500)
@@ -174,9 +174,9 @@ class McpAPI:
             return web.json_response({"error": str(e)}, status=500)
 
     @docs(
-        tags=["MCP / Runs"],
-        summary="List all runs",
-        description="List all MLflow runs with pagination support. Returns basic information about each run.",
+        tags=["MCP / Run History"],
+        summary="List execution history",
+        description="Browse all historical ability factory and operation planner executions with pagination. Returns run metadata, prompts, and results.",
     )
     @response_schema(ListRunsResponseSchema, 200)
     @response_schema(ErrorResponseSchema, 500)
@@ -237,9 +237,9 @@ class McpAPI:
             return web.json_response({"error": str(e)}, status=500)
 
     @docs(
-        tags=["MCP / Runs"],
-        summary="Get run details",
-        description="Get detailed information for a specific run including full execution trajectory, parameters, and tags.",
+        tags=["MCP / Run History"],
+        summary="Get detailed run information",
+        description="Get comprehensive details for a specific execution including full LLM reasoning trajectory, tool calls, parameters, and results.",
     )
     @response_schema(GetRunDetailResponseSchema, 200)
     @response_schema(ErrorResponseSchema, 400)

--- a/hook.py
+++ b/hook.py
@@ -108,3 +108,5 @@ async def enable(services):
     app.router.add_route('GET', '/plugin/mcp/status', mcp_api.status)
     app.router.add_route('POST', "/plugin/mcp/rag/upload", mcp_api.upload_rag)
     app.router.add_route('GET', "/plugin/mcp/rag/list", mcp_api.list_rag)
+    app.router.add_route('GET', '/plugin/mcp/runs', mcp_api.list_runs)
+    app.router.add_route('GET', '/plugin/mcp/runs/detail', mcp_api.get_run_detail)


### PR DESCRIPTION
## Description

This pull request adds Marshmallow schemas to the MCP plugin API and integrates them with `aiohttp_apispec` to enable automatic validation and OpenAPI documentation to work with core Caldera `api/docs`. 

**API Schema Definitions**

* Added new schema modules: `base_schemas.py`, `execute_schemas.py`, `status_schemas.py`, `rag_schemas.py`, and `runs_schemas.py` to define standardized request and response formats for error handling, execution, status, RAG file management, and run history. 

**API Endpoint Documentation and Validation**

* Updated `app/mcp_api.py` to import the new schemas and annotate all major endpoints (`execute`, `status`, `upload_rag`, `list_rag`, `list_runs`, `get_run_detail`) with OpenAPI documentation and request/response schema validation using `aiohttp_apispec`. 

**Endpoint Registration**

* Registered new run history endpoints (`/plugin/mcp/runs`, `/plugin/mcp/runs/detail`) in the plugin hook for full run listing and detail retrieval.

<img width="1383" height="557" alt="image" src="https://github.com/user-attachments/assets/693483c0-8916-45a6-825a-cd69a83b22b2" />

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Fresh install of Caldera with MCP Plugin to ensure proper population of MCP plugin Swagger Docs endpoints.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
