### PR TITLE
fix: read Caldera host, port, and API key from conf/default.yml

### DIFF
--- a/app/mcp_factory_client.py
+++ b/app/mcp_factory_client.py
@@ -54,6 +54,17 @@ def get_env(lm_settings=None):
         env['DSPY_TEMPERATURE'] = str(lm_settings.get('temperature') or 0.5)
         env['DSPY_MAX_TOKENS'] = str(lm_settings.get('max_tokens') or 10000)
 
+    # Pass Caldera connection config to subprocess
+    try:
+        caldera_config = BaseWorld.strip_yml('conf/default.yml')[0]
+        host = caldera_config.get('host', 'localhost')
+        port = caldera_config.get('port', 8888)
+        api_key = caldera_config.get('api_key_red', 'ADMIN123')
+        env['CALDERA_URL'] = f"http://{host}:{port}/api/v2/"
+        env['CALDERA_API_KEY'] = str(api_key)
+    except Exception as e:
+        print(f"[MCP] Failed to load Caldera config for subprocess: {e}")
+
     return env
 
 mlflow.set_tracking_uri("http://localhost:5000")

--- a/app/mcp_planner_client.py
+++ b/app/mcp_planner_client.py
@@ -59,6 +59,17 @@ def get_env(lm_settings=None):
         env['DSPY_TEMPERATURE'] = str(lm_settings.get('temperature') or 0.5)
         env['DSPY_MAX_TOKENS'] = str(lm_settings.get('max_tokens') or 10000)
 
+    # Pass Caldera connection config to subprocess
+    try:
+        caldera_config = BaseWorld.strip_yml('conf/default.yml')[0]
+        host = caldera_config.get('host', 'localhost')
+        port = caldera_config.get('port', 8888)
+        api_key = caldera_config.get('api_key_red', 'ADMIN123')
+        env['CALDERA_URL'] = f"http://{host}:{port}/api/v2/"
+        env['CALDERA_API_KEY'] = str(api_key)
+    except Exception as e:
+        print(f"[MCP] Failed to load Caldera config for subprocess: {e}")
+
     return env
 
 mlflow.set_tracking_uri("http://localhost:5000")

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import time
 import collections
 import uuid
+import os
 
 from factory import CreateCommand
 mcp = FastMCP("Caldera API MCP Server")
@@ -45,8 +46,8 @@ class CalderaRequest:
 
 
 caldera_request = CalderaRequest(
-    url="http://localhost:8888/api/v2/",
-    api_key="ADMIN123",
+    url=os.environ.get("CALDERA_URL", "http://localhost:8888/api/v2/"),
+    api_key=os.environ.get("CALDERA_API_KEY", "ADMIN123"),
 )
 
 


### PR DESCRIPTION
## Description

`app/mcp_server.py` hardcoded the Caldera API connection details (`localhost:8888` and `ADMIN123`), completely ignoring the `host`, `port`, and `api_key_red` values configured in `conf/default.yml`. This caused all MCP tool calls to fail when Caldera is deployed on a non-localhost IP or with a non-default port/API key.

The fix reads those values in `get_env()` in both `mcp_planner_client.py` and `mcp_factory_client.py`, and passes them to the `mcp_server.py` subprocess as `CALDERA_URL` and `CALDERA_API_KEY` environment variables — following the same pattern already used for LLM config. `mcp_server.py` reads them via `os.environ.get()` with the original hardcoded values as safe fallbacks.

Closes #5

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually tested by configuring Caldera with `host: 203.0.113.1` in `conf/default.yml` and triggering both factory and planner MCP executions. Prior to the fix all API calls failed with a connection error; after the fix the MCP server correctly connects to the configured host, port, and API key.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
