### PR TITLE
fix: terminate MLflow server when Caldera exits

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -5,6 +5,7 @@ import time
 import traceback
 import logging
 import psutil
+import atexit
 
 from app.utility.base_world import BaseWorld
 
@@ -53,6 +54,18 @@ def is_port_open(port):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         return sock.connect_ex(('127.0.0.1', port)) == 0
 
+_mlflow_proc = None
+
+def _shutdown_mlflow():
+    """Terminate the MLflow server process started by this plugin."""
+    if _mlflow_proc is not None and _mlflow_proc.poll() is None:
+        log.info("[MCP] Shutting down MLflow server...")
+        _mlflow_proc.terminate()
+        try:
+            _mlflow_proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            _mlflow_proc.kill()
+
 # 🔁 Start MLflow server if it's not already running
 if not is_port_open(5000):
     # 🧼 Kill old MLflow server if it exists
@@ -61,13 +74,14 @@ if not is_port_open(5000):
         plugin_dir = os.path.dirname(os.path.abspath(__file__))
         mlruns_path = os.path.join(plugin_dir, 'mlruns')
         db_path = os.path.join(plugin_dir, 'mlruns.db')
-        subprocess.Popen([
+        _mlflow_proc = subprocess.Popen([
             "mlflow", "server",
             "--backend-store-uri", f"sqlite:///{db_path}",
             "--default-artifact-root", mlruns_path,
             "--host", "127.0.0.1",
             "--port", "5000"
         ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        atexit.register(_shutdown_mlflow)
         log.debug("[MCP] Starting MLflow server at http://localhost:5000")
     except Exception as e:
         log.error(f"[MCP] Failed to start MLflow server: {e}")


### PR DESCRIPTION
## Description

`hook.py` started the MLflow server with `subprocess.Popen()` but discarded the process reference,
leaving MLflow running as an orphan after Caldera shuts down.

MLflow internally spawns worker processes via Python `multiprocessing`. When the MLflow parent dies
without cleanup, those workers get reparented to `init` (`PID=1`) and continue listening on port 5000
indefinitely. Repeated Caldera restarts accumulate these orphaned processes.

The fix stores the `Popen` reference in `_mlflow_proc` and registers an `atexit` handler
(`_shutdown_mlflow`) that calls `terminate()` on exit, with a 5-second timeout before force `kill()`.

Closes #7

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Started Caldera with the MCP plugin enabled
2. Confirmed MLflow was listening: `ss -tlnp | grep 5000`
3. Stopped Caldera (Ctrl+C)
4. Confirmed MLflow was no longer listening: `ss -tlnp | grep 5000`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
