### PR TITLE
fix: correct ability executors creation

### DIFF
--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -400,8 +400,8 @@ def create_windows_ability(
     created_command = create_command(command_description, "windows")
     # Create the executor object with default values for optional fields
     executor = {
-        "name": "windows",
-        "platform": "psh",
+        "name": "psh",
+        "platform": "windows",
         "command": created_command,
         "code": None,
         "language": None,
@@ -467,8 +467,8 @@ def create_linux_ability(
 
     # Create the executor object with default values for optional fields
     executor = {
-        "name": "linux",
-        "platform": "sh",
+        "name": "sh",
+        "platform": "linux",
         "command": created_command,
         "code": None,
         "language": None,


### PR DESCRIPTION
## Description

The `create_linux_ability` and `create_windows_ability` functions in `mcp_server.py` produce abilities with swapped `name` and `platform` values in the executor object. This causes the Caldera agent to silently skip all abilities created through the MCP plugin, since the agent cannot match the executor to its platform.

These fixes swapped between the name and the platform values in the executor object created in both aforementioned functions and now the abilities can be executed in the operation run.

Closes #10 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
1. Started Caldera with the MCP plugin enabled
2. At least one active Linux sandcat agent (or a Windows agent for the Windows test) (Tested on GNS3 tolpology)
3. Used the MCP operation planner plugin to create multiple Linux abilities covering different tactics (e.g., discovery, collection, credential-access), using them to create an adversary and operation.
4. Confirm in the Caldera UI under *Adversaries* in the generated adversary name that each ability include executors in the correct format.
5. Confirm in the Caldera UI under *Operations* in the generated operation that:
   - The operation state progresses from "running" to "finished"
   - Each ability transitions through queued → running → finished (not skipped)
   - Each ability produces output visible in the operation link results


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
