### PR TITLE
Pin dependency versions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dspy
-mcp
-mlflow
+dspy>=2.6,<3
+mcp>=1.0,<2
+mlflow>=2.0,<3


### PR DESCRIPTION
## Summary
- Pin `dspy`, `mcp`, and `mlflow` to compatible version ranges (`>=current,<next_major`) in `requirements.txt`
- These are fast-moving libraries and unpinned dependencies risk unexpected breakage from upstream changes
- Uses `>=min,<next_major` style pins to allow patch/minor updates while preventing breaking major version bumps

## Test plan
- [ ] Verify `pip install -r requirements.txt` resolves and installs compatible versions
- [ ] Run existing tests to confirm no regressions with pinned versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)