### PR TITLE
Replace hardcoded Caldera credentials with env vars

### DIFF
--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import time
 import collections
 import uuid
+import os
 
 from factory import CreateCommand
 mcp = FastMCP("Caldera API MCP Server")
@@ -45,8 +46,8 @@ class CalderaRequest:
 
 
 caldera_request = CalderaRequest(
-    url="http://localhost:8888/api/v2/",
-    api_key="ADMIN123",
+    url=os.environ.get("CALDERA_URL", "http://localhost:8888/api/v2/"),
+    api_key=os.environ.get("CALDERA_API_KEY", "ADMIN123"),
 )
 
 


### PR DESCRIPTION
## Summary

- Replace hardcoded API key (`ADMIN123`) and URL in `app/mcp_server.py` with `os.environ.get()` calls
- Credentials are now read from `CALDERA_API_KEY` and `CALDERA_URL` environment variables
- Previous default values are preserved as fallbacks for backward compatibility

## Motivation

Hardcoded credentials in source code pose a security risk, especially in public repositories. This change allows users to configure credentials via environment variables without modifying the source, while maintaining backward compatibility with the existing defaults.

## Test plan

- [ ] Verify the MCP server starts correctly without environment variables set (uses defaults)
- [ ] Verify the MCP server reads `CALDERA_API_KEY` and `CALDERA_URL` from the environment when set
- [ ] Verify API calls succeed with custom credentials passed via environment variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)