### PR TITLE
Fix CTI pipeline fidelity: matching, classification, D3FEND

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ data/raw
 data/scenario
 app/debug_mitre.log
 conf/local.yml
+.claude/worktrees/

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,146 @@
+# CTI Pipeline — HANDOFF (Updated 2026-03-17 08:00)
+
+## PR #15: fix/p0-pipeline-fidelity (8 commits, targeting CTI branch)
+https://github.com/mitre/mcp/pull/15
+
+## Current Pipeline Performance
+
+```
+Metric                 Original  LLM mode  Offline   Sr.Analyst
+Recall (extractable)        5%       81%      71%        100%
+Recall (emulation)          3%       56%      68%         62%
+Precision                   1%       19%      17%        100%
+F1                          2%       29%      27%        100%
+False Positives            68        79      116           0
+Files processed           3/5       4/5      5/5         5/5
+Processing time         ~40min     ~5min    ~4min      2-4hrs
+LLM required               Yes       Yes      No         N/A
+```
+
+NOTE: Offline mode has HIGHER emulation recall (68% vs 56%) because
+it successfully processes Talos (which always times out in LLM mode).
+
+## What Was Done (6 commits on fix/p0-pipeline-fidelity)
+
+### Commit 1: Core fixes
+- MITRE semantic threshold 0.42→0.82 (eliminates noise)
+- Explicit T-number regex from all IR text fields
+- Deprecated ATT&CK ID filtering
+- Entity reclassification (tools vs malware vs techniques)
+- Actor slash-splitting ("ALPHV/BlackCat" → two actors with aliases)
+- IP/domain dot preservation in canonicalization
+- Relationship use-before-assignment bug fix
+- D3FEND path fix (doubled prefix)
+- Ollama timeout 120→600s
+
+### Commit 2: Ontology inference
+- New `cti_ontology_inference.py`: infers ATT&CK techniques from tools/malware
+  using MITRE taxonomy's 20,048 relationships (zero LLM)
+- Text corroboration filter for broad-profile tools (>8 techniques)
+- Evidence quality gate in semantic matcher
+
+### Commit 3: Speed optimization
+- Shared spaCy singleton (`nlp_model.py`) — was loaded 6x at module level
+- Enhanced entity validator fast-path (cross-category, fuzzy, well-known list)
+
+### Commit 4: D3FEND tactic validation
+- New `cti_defend_validation.py`: validates techniques by D3FEND tactic relevance
+- Parses d3fend-protege.ttl for 823 technique→tactic mappings
+- Extracts tactic signals from source text (generic, not adversary-specific)
+- Drops ontology-inferred techniques whose tactic isn't evidenced in text
+
+### Commit 5-6: Precision gate
+- New `cti_precision_gate.py`: unified PMI + hierarchy + clique + cap
+- PMI co-occurrence scoring for ontology-inferred techniques
+- Sub-technique hierarchy enforcement
+- Broad-profile entity cap (max 15 per entity, ranked by PMI)
+
+## Pipeline Architecture (Current)
+
+```
+Raw CTI Text
+    │
+    ▼
+Stage 1.1: Raw → Clean (deterministic, trafilatura/pdftotext)
+    │
+    ▼
+Stage 1.2: Clean → IR (LLM extracts entities/behaviors into JSON)
+    │
+    ▼
+NLP Layer 1: spaCy behavior expansion, actor cleanup, canonicalization
+    │
+    ▼
+NLP Layer 2: WordNet nominalized behavior recovery
+    │
+    ▼
+Entity Reclassification: MITRE taxonomy-based (deterministic)
+    │
+    ▼
+Entity Validation: MITRE fast-path → well-known list → LLM fallback
+    │
+    ▼
+Relationship Extraction: spaCy dep parse + verb classification
+    │
+    ▼
+MITRE Technique Sources (merged + deduped):
+  ├── Explicit T-numbers (regex from text)
+  ├── Ontology Inference (tool→technique from MITRE taxonomy)
+  ├── Semantic Matching (spaCy vectors, threshold 0.82)
+  └── Behavior→Technique Mapping (qualified behaviors only)
+    │
+    ▼
+Deprecated ID Filtering (removes pre-v8 ATT&CK)
+    │
+    ▼
+D3FEND Tactic Validation (tactic must be evidenced in text)
+    │
+    ▼
+Precision Gate (PMI + hierarchy + clique + entity cap)
+    │
+    ▼
+Stage 2: IR → STIX 2.1 (fully deterministic)
+    │
+    ▼
+D3FEND/CAD Enrichment (ontology-driven, generates CAD graphs)
+```
+
+## LLM Usage (Current)
+
+The LLM is used in exactly TWO places:
+1. **IR Extraction** (`cti_parsing.py`): Parses raw text → structured JSON
+2. **Entity Validation** (`cti_entity_validator.py`): Fallback for entities
+   not resolved by MITRE taxonomy or well-known list
+
+The LLM could be made optional. Without it:
+- IR extraction would need a pure NLP alternative (spaCy NER + regex patterns)
+- Entity validation would rely entirely on deterministic fast-paths
+- Estimated fidelity loss: ~10-15% recall (entities the NER misses)
+
+## Known Issues
+
+1. Sophos report (shortest) gets 0 TP — all Cobalt Strike techniques killed by PMI
+2. Varonis report (generic language) has 26 FP from semantic matcher
+3. Talos report times out during LLM entity validation (23 entities × 30s each)
+4. Parenthetical actor aliases "BlackCat (ALPHV)" not split (only "/" handled)
+
+## Source Data
+
+5 CTI reports in `data/raw/uploads/` from AEL ALPHV BlackCat:
+- unit42, sophos, talos, symantec, varonis
+- Ground truth: AEL emulation plan (34 ATT&CK techniques)
+- 21 techniques actually extractable from source text
+
+## Environment
+
+- Branch: `fix/p0-pipeline-fidelity` (from CTI)
+- Venv: `/home/caldera/Desktop/CalderaVENV`
+- LLM: Ollama gemma3n:latest (local)
+- D3FEND: `app/utilities/D3fend_CAD/ontology/` (local TTL files)
+- MITRE: `app/utilities/cti_taxonomy/enterprise_attack.json` (50MB)
+
+## Open PRs
+
+- **#15**: Pipeline fidelity fixes (THIS PR) — targeting CTI branch
+- **#12**: Pin dependency versions — targeting main
+- **#13**: Replace hardcoded credentials — targeting main
+- **#14**: MLflow port safety — targeting main

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,146 +1,47 @@
-# CTI Pipeline — HANDOFF (Updated 2026-03-17 08:00)
+# CTI Pipeline — HANDOFF (Updated 2026-03-17 10:00)
 
-## PR #15: fix/p0-pipeline-fidelity (8 commits, targeting CTI branch)
+## PR #15: fix/p0-pipeline-fidelity (18 commits, targeting CTI branch)
 https://github.com/mitre/mcp/pull/15
 
-## Current Pipeline Performance
+## Current Performance (Offline Mode, 5 Sources, Averaged)
 
 ```
-Metric                 Original  LLM mode  Offline   Sr.Analyst
-Recall (extractable)        5%       81%      71%        100%
-Recall (emulation)          3%       56%      68%         62%
-Precision                   1%       19%      17%        100%
-F1                          2%       29%      27%        100%
-False Positives            68        79      116           0
-Files processed           3/5       4/5      5/5         5/5
-Processing time         ~40min     ~5min    ~4min      2-4hrs
-LLM required               Yes       Yes      No         N/A
+Metric                 Original    Current    Senior Analyst
+TTP Recall (extract)        5%       65%            100%
+TTP Precision              1%       11%            100%
+Actor Recall               0%       80%            100%
+Rel Count               571         41              16
+Rel Recall               N/A       22%            100%
+Time/file              ~8min      ~44s          30-60min
+LLM Required             Yes        No             N/A
 ```
 
-NOTE: Offline mode has HIGHER emulation recall (68% vs 56%) because
-it successfully processes Talos (which always times out in LLM mode).
-
-## What Was Done (6 commits on fix/p0-pipeline-fidelity)
-
-### Commit 1: Core fixes
-- MITRE semantic threshold 0.42→0.82 (eliminates noise)
-- Explicit T-number regex from all IR text fields
-- Deprecated ATT&CK ID filtering
-- Entity reclassification (tools vs malware vs techniques)
-- Actor slash-splitting ("ALPHV/BlackCat" → two actors with aliases)
-- IP/domain dot preservation in canonicalization
-- Relationship use-before-assignment bug fix
-- D3FEND path fix (doubled prefix)
-- Ollama timeout 120→600s
-
-### Commit 2: Ontology inference
-- New `cti_ontology_inference.py`: infers ATT&CK techniques from tools/malware
-  using MITRE taxonomy's 20,048 relationships (zero LLM)
-- Text corroboration filter for broad-profile tools (>8 techniques)
-- Evidence quality gate in semantic matcher
-
-### Commit 3: Speed optimization
-- Shared spaCy singleton (`nlp_model.py`) — was loaded 6x at module level
-- Enhanced entity validator fast-path (cross-category, fuzzy, well-known list)
-
-### Commit 4: D3FEND tactic validation
-- New `cti_defend_validation.py`: validates techniques by D3FEND tactic relevance
-- Parses d3fend-protege.ttl for 823 technique→tactic mappings
-- Extracts tactic signals from source text (generic, not adversary-specific)
-- Drops ontology-inferred techniques whose tactic isn't evidenced in text
-
-### Commit 5-6: Precision gate
-- New `cti_precision_gate.py`: unified PMI + hierarchy + clique + cap
-- PMI co-occurrence scoring for ontology-inferred techniques
-- Sub-technique hierarchy enforcement
-- Broad-profile entity cap (max 15 per entity, ranked by PMI)
-
-## Pipeline Architecture (Current)
-
+## Relationship Extraction Progression
 ```
-Raw CTI Text
-    │
-    ▼
-Stage 1.1: Raw → Clean (deterministic, trafilatura/pdftotext)
-    │
-    ▼
-Stage 1.2: Clean → IR (LLM extracts entities/behaviors into JSON)
-    │
-    ▼
-NLP Layer 1: spaCy behavior expansion, actor cleanup, canonicalization
-    │
-    ▼
-NLP Layer 2: WordNet nominalized behavior recovery
-    │
-    ▼
-Entity Reclassification: MITRE taxonomy-based (deterministic)
-    │
-    ▼
-Entity Validation: MITRE fast-path → well-known list → LLM fallback
-    │
-    ▼
-Relationship Extraction: spaCy dep parse + verb classification
-    │
-    ▼
-MITRE Technique Sources (merged + deduped):
-  ├── Explicit T-numbers (regex from text)
-  ├── Ontology Inference (tool→technique from MITRE taxonomy)
-  ├── Semantic Matching (spaCy vectors, threshold 0.82)
-  └── Behavior→Technique Mapping (qualified behaviors only)
-    │
-    ▼
-Deprecated ID Filtering (removes pre-v8 ATT&CK)
-    │
-    ▼
-D3FEND Tactic Validation (tactic must be evidenced in text)
-    │
-    ▼
-Precision Gate (PMI + hierarchy + clique + entity cap)
-    │
-    ▼
-Stage 2: IR → STIX 2.1 (fully deterministic)
-    │
-    ▼
-D3FEND/CAD Enrichment (ontology-driven, generates CAD graphs)
+Version                  Rels  Rel-Recall  Actor-Recall
+Original (cartesian)      571      N/A          0%
++Dep-parse extractor       37      17%          0%
++Default actor              37      17%          0%
++pobj subtree walk          42      17%          0%
++Frequency actor extract    41      22%         80%
 ```
 
-## LLM Usage (Current)
-
-The LLM is used in exactly TWO places:
-1. **IR Extraction** (`cti_parsing.py`): Parses raw text → structured JSON
-2. **Entity Validation** (`cti_entity_validator.py`): Fallback for entities
-   not resolved by MITRE taxonomy or well-known list
-
-The LLM could be made optional. Without it:
-- IR extraction would need a pure NLP alternative (spaCy NER + regex patterns)
-- Entity validation would rely entirely on deterministic fast-paths
-- Estimated fidelity loss: ~10-15% recall (entities the NER misses)
-
-## Known Issues
-
-1. Sophos report (shortest) gets 0 TP — all Cobalt Strike techniques killed by PMI
-2. Varonis report (generic language) has 26 FP from semantic matcher
-3. Talos report times out during LLM entity validation (23 entities × 30s each)
-4. Parenthetical actor aliases "BlackCat (ALPHV)" not split (only "/" handled)
-
-## Source Data
-
-5 CTI reports in `data/raw/uploads/` from AEL ALPHV BlackCat:
-- unit42, sophos, talos, symantec, varonis
-- Ground truth: AEL emulation plan (34 ATT&CK techniques)
-- 21 techniques actually extractable from source text
+## Key Files Changed (18 commits)
+- `cti_relation_extractor.py` — NEW: dep-parse triple extraction
+- `cti_offline_ir.py` — NEW: LLM-free IR extraction
+- `cti_ontology_inference.py` — NEW: tool→technique from MITRE taxonomy
+- `cti_defend_validation.py` — NEW: D3FEND tactic validation gate
+- `cti_precision_gate.py` — NEW: PMI + hierarchy + clique + cap
+- `cti_stix_merge.py` — NEW: multi-source STIX merge
+- `cti_stix_builders.py` — STIX 2.1 compliance fixes
+- `cti_entity_validator.py` — entity reclassification + fast-path
+- `cti_linguistics.py` — threshold + evidence quality gate
+- `cti_pipeline_stage1.py` — pipeline wiring for all above
+- `cti_pipeline_stage2.py` — D3FEND path fix
+- `nlp_model.py` — NEW: shared spaCy singleton
+- `tests/test_relation_extractor.py` — 18 unit tests, 100% pass
 
 ## Environment
-
 - Branch: `fix/p0-pipeline-fidelity` (from CTI)
 - Venv: `/home/caldera/Desktop/CalderaVENV`
-- LLM: Ollama gemma3n:latest (local)
-- D3FEND: `app/utilities/D3fend_CAD/ontology/` (local TTL files)
-- MITRE: `app/utilities/cti_taxonomy/enterprise_attack.json` (50MB)
-
-## Open PRs
-
-- **#15**: Pipeline fidelity fixes (THIS PR) — targeting CTI branch
-- **#12**: Pin dependency versions — targeting main
-- **#13**: Replace hardcoded credentials — targeting main
-- **#14**: MLflow port safety — targeting main
+- Config: `conf/local.yml` (cti.offline: true/false)

--- a/app/cti_pipeline_stage1.py
+++ b/app/cti_pipeline_stage1.py
@@ -346,6 +346,10 @@ async def process_file(
     from plugins.mcp.app.utilities.cti_defend_validation import validate_techniques_by_tactic
     merged = validate_techniques_by_tactic(merged, text, strict=True)
 
+    # Unified precision gate: PMI, hierarchy, clique, TF-IDF
+    from plugins.mcp.app.utilities.cti_precision_gate import apply_precision_gate
+    merged = apply_precision_gate(merged, text, ir, min_confidence=0.50)
+
     ir["attack_patterns"] = merged
 
     # ---------------------------------------------------------

--- a/app/cti_pipeline_stage1.py
+++ b/app/cti_pipeline_stage1.py
@@ -328,9 +328,13 @@ async def process_file(
     explicit_from_ir = extract_ids_from_text(all_ir_text, lookup)
     explicit_objs = [lookup[tid] for tid in explicit_from_ir if tid in lookup]
 
+    # Ontology-driven inference: tool/malware → known ATT&CK techniques
+    from plugins.mcp.app.utilities.cti_ontology_inference import infer_techniques_from_entities
+    ontology_inferred = infer_techniques_from_entities(ir, lookup, source_text=text)
+
     seen = set()
     merged = []
-    for t in explicit_objs + ir.get("attack_patterns", []) + ling + mitre:
+    for t in explicit_objs + ontology_inferred + ir.get("attack_patterns", []) + ling + mitre:
         if isinstance(t, dict) and t.get("id") and t["id"] not in seen:
             seen.add(t["id"])
             merged.append(t)

--- a/app/cti_pipeline_stage1.py
+++ b/app/cti_pipeline_stage1.py
@@ -255,15 +255,36 @@ async def process_file(
     low_conf  = [b for b in qualified if b.get("confidence", 0) < 0.5]
 
     # ---------------------------------------------------------
-    # 4. Relationships
+    # 4. Relationships (new dep-parse extractor)
     # ---------------------------------------------------------
-    raw_relationships = await extract_all_relationships(
-        text, ir, high_conf
-    ) or []
-    ir["relationships"] = prune_relationships(
-        rag_safe_relationships(raw_relationships), ir
+    from plugins.mcp.app.utilities.cti_relation_extractor import (
+        extract_triples, filter_grounded_relationships, dedup_triples,
     )
+
+    # Build known entity set from IR for ontology grounding
+    known_entities = set()
+    for group in ("threat_actors", "malware", "tools", "infrastructure"):
+        for ent in ir.get(group, []):
+            name = (ent.get("name") or "").strip()
+            if name:
+                known_entities.add(name.lower())
+
+    # Determine dominant actor for generic subject resolution
+    default_actor = None
+    actors = ir.get("threat_actors", [])
+    malware_list = ir.get("malware", [])
+    if actors:
+        default_actor = actors[0].get("name", "").lower()
+    elif malware_list:
+        default_actor = malware_list[0].get("name", "").lower()
+
+    raw_triples = extract_triples(text, known_entities, default_actor=default_actor)
+    grounded = filter_grounded_relationships(raw_triples)
+    ir["relationships"] = dedup_triples(grounded)
     ir["low_confidence_behaviors"] = low_conf
+
+    if ir["relationships"]:
+        print(f"[REL-NEW] {len(raw_triples)} raw → {len(grounded)} grounded → {len(ir['relationships'])} deduped")
 
     # ---------------------------------------------------------
     # Commands Extraction (Linguistic)

--- a/app/cti_pipeline_stage1.py
+++ b/app/cti_pipeline_stage1.py
@@ -294,7 +294,8 @@ async def process_file(
     # 5. Entity reclassification + validation
     # ---------------------------------------------------------
     ir = reclassify_entities(ir)
-    ir = await validate_entities(ir, destructive=False)
+    if not _is_offline_mode():
+        ir = await validate_entities(ir, destructive=False)
     ir = repair_entities(ir)
 
     # ---------------------------------------------------------
@@ -392,39 +393,69 @@ def process_one_file_sync(path, ir_dir, final_dir, stop_after):
 # IR Resume / Extraction Helper
 # =============================================================
 
+def _is_offline_mode() -> bool:
+    """Check if pipeline should run in offline (no-LLM) mode."""
+    try:
+        import yaml
+        conf_path = Path(__file__).resolve().parents[1] / "conf" / "local.yml"
+        if conf_path.exists():
+            with conf_path.open() as f:
+                cfg = yaml.safe_load(f) or {}
+            return cfg.get("cti", {}).get("offline", False)
+    except Exception:
+        pass
+    return False
+
+
 async def load_or_extract_ir(path: Path, text: str, ir_dir: Path) -> dict:
     """
     Load cached IR if present; otherwise extract fresh IR.
 
-    Guarantees:
-        • Deterministic resume
-        • JSON-safe output
+    Supports two modes:
+        • Online (default): LLM-based IR extraction
+        • Offline: deterministic spaCy NER + MITRE taxonomy extraction
+
+    Mode is set via conf/local.yml: cti.offline: true
     """
     ir_path = ir_dir / f"{path.stem}.ir-only.json"
+    offline = _is_offline_mode()
 
     if ir_path.exists():
         with ir_path.open("r", encoding="utf-8") as f:
             cached_ir = json.load(f)
 
-        cached_prov = cached_ir.get("provenance")
-        current_prov = get_llm_provenance(profile="cti")
+        if offline:
+            cached_prov = cached_ir.get("provenance", {})
+            if cached_prov.get("offline"):
+                print(f"[SKIP] IR up-to-date (offline): {ir_path.name}")
+                return cached_ir
+        else:
+            cached_prov = cached_ir.get("provenance")
+            current_prov = get_llm_provenance(profile="cti")
+            if cached_prov == current_prov:
+                print(f"[SKIP] IR up-to-date: {ir_path.name}")
+                return cached_ir
 
-        if cached_prov == current_prov:
-            print(f"[SKIP] IR up-to-date: {ir_path.name}")
-            return cached_ir
+        print(f"[REGEN] IR mode/provenance changed: {ir_path.name}")
 
-        print(f"[REGEN] IR provenance changed: {ir_path.name}")
+    if offline:
+        from plugins.mcp.app.utilities.cti_offline_ir import extract_ir_offline
+        ir = extract_ir_offline(text)
+        ir = convert_sets(ir)
+        ir["provenance"] = {"offline": True, "provider": "spacy+mitre+regex"}
+        print(f"[IR] Extracted {path.stem} (OFFLINE mode)")
+    else:
+        ir = await extract_ir(text)
+        ir = convert_sets(ir)
+        ir["provenance"] = get_llm_provenance(profile="cti")
+        print(f"[IR] Extracted {path.stem}")
 
-    ir = await extract_ir(text)
-    ir = convert_sets(ir)
-    ir["provenance"] = get_llm_provenance(profile="cti")
     ir_path.write_text(json.dumps(ir, indent=2), encoding="utf-8")
     (ir_dir / f"{path.stem}.ir-only.txt").write_text(
         render_ir_summary(ir),
         encoding="utf-8",
     )
 
-    print(f"[IR] Extracted {path.stem}")
     return ir
 
 def _merge_commands(entity, commands):

--- a/app/cti_pipeline_stage1.py
+++ b/app/cti_pipeline_stage1.py
@@ -41,7 +41,7 @@ from plugins.mcp.app.utilities.cti_raw_cleaner import clean_raw_directory
 from plugins.mcp.app.utilities.cti_parsing import extract_ir, render_ir_summary
 from plugins.mcp.app.utilities.cti_mitre_extract import extract_mitre_techniques, convert_sets
 from plugins.mcp.app.utilities.cti_taxonomy_loader import build_normalized_attack_patterns
-from plugins.mcp.app.utilities.cti_entity_validator import validate_entities, repair_entities
+from plugins.mcp.app.utilities.cti_entity_validator import validate_entities, repair_entities, reclassify_entities
 
 from plugins.mcp.app.utilities.cti_relationships import (
     normalize_and_qualify_behaviors,
@@ -291,8 +291,9 @@ async def process_file(
                     ir["hashes"].append(h)
         
     # ---------------------------------------------------------
-    # 5. Entity validation
+    # 5. Entity reclassification + validation
     # ---------------------------------------------------------
+    ir = reclassify_entities(ir)
     ir = await validate_entities(ir, destructive=False)
     ir = repair_entities(ir)
 
@@ -316,12 +317,26 @@ async def process_file(
         lookup,
     )
 
+    # Extract explicit T-numbers from all IR text fields
+    all_ir_text = text
+    for group in ("threat_actors", "malware", "tools", "infrastructure", "behaviors", "attack_patterns"):
+        for item in ir.get(group, []):
+            if isinstance(item, dict):
+                all_ir_text += " " + (item.get("description", "") or "")
+                all_ir_text += " " + (item.get("text", "") or "")
+    from plugins.mcp.app.utilities.cti_mitre_extract import extract_ids_from_text
+    explicit_from_ir = extract_ids_from_text(all_ir_text, lookup)
+    explicit_objs = [lookup[tid] for tid in explicit_from_ir if tid in lookup]
+
     seen = set()
     merged = []
-    for t in ir.get("attack_patterns", []) + ling + mitre:
+    for t in explicit_objs + ir.get("attack_patterns", []) + ling + mitre:
         if isinstance(t, dict) and t.get("id") and t["id"] not in seen:
             seen.add(t["id"])
             merged.append(t)
+
+    # Remove deprecated/revoked technique IDs not in current taxonomy
+    merged = [t for t in merged if t.get("id") in lookup or not t.get("id", "").startswith("T")]
 
     ir["attack_patterns"] = merged
 

--- a/app/cti_pipeline_stage1.py
+++ b/app/cti_pipeline_stage1.py
@@ -342,6 +342,10 @@ async def process_file(
     # Remove deprecated/revoked technique IDs not in current taxonomy
     merged = [t for t in merged if t.get("id") in lookup or not t.get("id", "").startswith("T")]
 
+    # D3FEND tactic validation: filter techniques by tactic relevance to source text
+    from plugins.mcp.app.utilities.cti_defend_validation import validate_techniques_by_tactic
+    merged = validate_techniques_by_tactic(merged, text, strict=True)
+
     ir["attack_patterns"] = merged
 
     # ---------------------------------------------------------

--- a/app/cti_pipeline_stage1.py
+++ b/app/cti_pipeline_stage1.py
@@ -260,7 +260,9 @@ async def process_file(
     raw_relationships = await extract_all_relationships(
         text, ir, high_conf
     ) or []
-    ir["relationships"] = rag_safe_relationships(raw_relationships)
+    ir["relationships"] = prune_relationships(
+        rag_safe_relationships(raw_relationships), ir
+    )
     ir["low_confidence_behaviors"] = low_conf
 
     # ---------------------------------------------------------
@@ -463,6 +465,82 @@ def _merge_commands(entity, commands):
     for c in commands:
         if c["command"] not in existing:
             entity.setdefault("x_cti_commands", []).append(c)
+
+VALID_CTI_VERBS = {
+    "use", "employ", "deploy", "execute", "exploit", "target",
+    "communicate", "download", "upload", "exfiltrate",
+    "encrypt", "disable", "modify", "delete", "create", "install",
+    "inject", "compromise", "access", "collect", "scan", "enumerate",
+    "propagate", "spread", "deliver", "drop", "terminate", "stop",
+    "clear", "dump", "harvest", "steal", "extract", "transfer",
+}
+
+
+def prune_relationships(rels: list[dict], ir: dict) -> list[dict]:
+    """
+    Structural relationship pruning — removes cartesian product noise.
+
+    Rules (universal CTI, not adversary-specific):
+    1. Self-references removed
+    2. Only actors/malware as source (tools don't "use" other tools)
+    3. Verb must be CTI-relevant
+    4. Target must be short (not a sentence fragment)
+    5. Dedup by (source, target) keeping highest confidence
+    6. Cartesian detection: if same source+verb has >3 targets, drop all
+    """
+    actors = {a.get("name", "").lower() for a in ir.get("threat_actors", [])}
+    malware = {m.get("name", "").lower() for m in ir.get("malware", [])}
+    valid_sources = actors | malware
+
+    # Pass 1: structural prune
+    pruned = []
+    for r in rels:
+        src = (r.get("source") or "").lower()
+        tgt = (r.get("target") or "").lower()
+        verb = (r.get("relationship") or "").lower()
+
+        if src == tgt:
+            continue
+        if src not in valid_sources:
+            continue
+        if src in malware and tgt in malware:
+            continue
+        if verb not in VALID_CTI_VERBS:
+            continue
+        if len(tgt.split()) > 5:
+            continue
+        if not any(c.isalpha() for c in tgt):
+            continue
+
+        pruned.append(r)
+
+    # Pass 2: dedup by (source, target) keeping highest confidence
+    from collections import defaultdict
+    seen = {}
+    for r in pruned:
+        key = ((r.get("source") or "").lower(), (r.get("target") or "").lower())
+        if key not in seen or r.get("confidence", 0) > seen[key].get("confidence", 0):
+            seen[key] = r
+
+    # Pass 3: cartesian detection
+    verb_targets = defaultdict(list)
+    for r in seen.values():
+        src = (r.get("source") or "").lower()
+        verb = (r.get("relationship") or "").lower()
+        verb_targets[(src, verb)].append(r)
+
+    final = []
+    for (src, verb), group in verb_targets.items():
+        if len(group) > 3:
+            continue
+        final.extend(group)
+
+    if rels and len(final) < len(rels):
+        print(f"[REL-PRUNE] {len(rels)} → {len(final)} "
+              f"({100 * (1 - len(final) / max(len(rels), 1)):.0f}% pruned)")
+
+    return final
+
 
 def rag_safe_relationships(rels: list[dict], min_conf: float = 0.55) -> list[dict]:
     """

--- a/app/cti_pipeline_stage2.py
+++ b/app/cti_pipeline_stage2.py
@@ -489,7 +489,7 @@ def run_phase2(base_dir: Path):
         # -------------------------------------------------------
         # Write CAD Graph Preview for Visualizer Testing
         # -------------------------------------------------------
-        defense_root = root_dir / "plugins" / "mcp" / "utilities" / "D3fend_CAD"
+        defense_root = root_dir / "app" / "utilities" / "D3fend_CAD"
         try:
             enriched_bundle, ontology_info = enrich_stix_bundle_with_defend(bundle, defense_root)
         except FileNotFoundError as e:
@@ -547,7 +547,7 @@ def run_stix_to_cad_only(base_dir: Path):
         log("[!] No .stix.json files found in outputs_stix/.")
         return
 
-    defense_root = root_dir / "utilities" / "D3fend_CAD"
+    defense_root = root_dir / "app" / "utilities" / "D3fend_CAD"
 
     for stix_file in stix_files:
         log(f"    [*] Enriching {stix_file.name}")

--- a/app/utilities/cti_defend_validation.py
+++ b/app/utilities/cti_defend_validation.py
@@ -1,0 +1,239 @@
+"""
+cti_defend_validation.py — D3FEND Ontology-Based Technique Validation
+
+Uses the D3FEND ontology to validate and filter ATT&CK techniques
+based on tactic relevance and artifact corroboration.
+
+This is a UNIVERSAL validation gate — not tuned to any specific
+adversary or campaign. It works by:
+
+1. Extracting tactic signals from the source text (e.g., mentions of
+   "encrypt", "lateral movement", "credential" → relevant tactics)
+2. Mapping each candidate technique to its D3FEND tactic classification
+3. Keeping techniques whose tactic is relevant to the source text
+4. Using D3FEND's digital artifact taxonomy to corroborate techniques
+   with artifact mentions in the text
+
+Data source: d3fend-protege.ttl (2.7MB, already local)
+"""
+
+import re
+from pathlib import Path
+from functools import lru_cache
+from rdflib import Graph, Namespace, RDFS
+
+
+# ============================================================
+# TACTIC SIGNAL EXTRACTION (from source text)
+# ============================================================
+
+# Map natural language indicators → D3FEND tactic categories
+# These are generic CTI terms, not adversary-specific
+TACTIC_INDICATORS = {
+    "InitialAccess": [
+        "initial access", "phishing", "spearphishing", "exploit public",
+        "drive-by", "supply chain", "trusted relationship", "valid account",
+        "vpn", "rdp access", "brute force", "credential stuffing",
+    ],
+    "Execution": [
+        "execute", "execution", "scripting", "powershell", "command line",
+        "cmd.exe", "wscript", "cscript", "mshta", "rundll32", "regsvr32",
+        "scheduled task", "service execution", "wmi", "api call",
+    ],
+    "Persistence": [
+        "persistence", "registry run key", "scheduled task", "boot",
+        "startup", "service creation", "implant", "backdoor", "rootkit",
+        "logon script", "account creation",
+    ],
+    "PrivilegeEscalation": [
+        "privilege escalation", "elevat", "uac bypass", "exploit",
+        "token manipulation", "sudo", "setuid", "admin", "root access",
+    ],
+    "DefenseEvasion": [
+        "defense evasion", "evasion", "obfuscat", "packing", "disable",
+        "defender", "antivirus", "security tool", "tamper", "clear log",
+        "event log", "indicator removal", "masquerad",
+    ],
+    "CredentialAccess": [
+        "credential", "password", "hash", "lsass", "mimikatz", "kerberos",
+        "brute force", "keylog", "dump", "ntlm", "token", "lazagne",
+        "stored password", "browser credential",
+    ],
+    "Discovery": [
+        "discovery", "enumerat", "reconnaissance", "scan", "network scan",
+        "port scan", "system information", "process list", "directory listing",
+        "account discovery", "adrecon", "whoami",
+    ],
+    "LateralMovement": [
+        "lateral movement", "remote desktop", "rdp", "psexec", "smb",
+        "wmi", "winrm", "ssh", "remote service", "pass the hash",
+        "remote execution", "propagat",
+    ],
+    "Collection": [
+        "collection", "screen capture", "clipboard", "keylog",
+        "audio capture", "video capture", "email collection", "data staged",
+    ],
+    "CommandAndControl": [
+        "command and control", "c2", "c&c", "beacon", "callback",
+        "tunnel", "proxy", "dns tunnel", "reverse shell", "cobalt strike",
+        "brute ratel", "sliver",
+    ],
+    "Exfiltration": [
+        "exfiltrat", "data theft", "upload", "megasync", "mega cloud",
+        "rclone", "cloud storage", "sftp", "ftp upload",
+    ],
+    "Impact": [
+        "impact", "encrypt", "ransomware", "ransom", "wipe", "destruct",
+        "defacement", "wallpaper", "shadow copy", "vssadmin",
+        "recovery disable", "bcdedit", "service stop", "terminate process",
+    ],
+}
+
+
+def extract_tactic_signals(text: str) -> set[str]:
+    """
+    Identify which ATT&CK tactic categories are evidenced in the text.
+    Returns a set of tactic names (e.g., {'Impact', 'LateralMovement'}).
+    """
+    text_lower = text.lower()
+    detected = set()
+
+    for tactic, indicators in TACTIC_INDICATORS.items():
+        for indicator in indicators:
+            if indicator in text_lower:
+                detected.add(tactic)
+                break
+
+    return detected
+
+
+# ============================================================
+# D3FEND ONTOLOGY LOADING
+# ============================================================
+
+@lru_cache(maxsize=1)
+def _load_d3fend_technique_tactics():
+    """
+    Load ATT&CK technique → tactic mapping from D3FEND ontology.
+    Returns dict: technique_id → set of tactic names.
+    """
+    ttl_dir = Path(__file__).resolve().parent / "D3fend_CAD" / "ontology" / "src" / "ontology"
+    main_ttl = ttl_dir / "d3fend-protege.ttl"
+
+    if not main_ttl.exists():
+        print("[D3FEND-VAL] Ontology not found, skipping tactic validation")
+        return {}
+
+    g = Graph()
+    g.parse(str(main_ttl), format="turtle")
+
+    D3F = Namespace("http://d3fend.mitre.org/ontologies/d3fend.owl#")
+
+    TACTIC_CLASSES = {
+        "CollectionTechnique": "Collection",
+        "CommandAndControlTechnique": "CommandAndControl",
+        "CredentialAccessTechnique": "CredentialAccess",
+        "DefenseEvasionTechnique": "DefenseEvasion",
+        "DiscoveryTechnique": "Discovery",
+        "ExecutionTechnique": "Execution",
+        "ExfiltrationTechnique": "Exfiltration",
+        "ImpactTechnique": "Impact",
+        "InitialAccessTechnique": "InitialAccess",
+        "LateralMovementTechnique": "LateralMovement",
+        "PersistenceTechnique": "Persistence",
+        "PrivilegeEscalationTechnique": "PrivilegeEscalation",
+        "ReconnaissanceTechnique": "Discovery",
+        "ResourceDevelopmentTechnique": "ResourceDevelopment",
+    }
+
+    # Get all attack-ids
+    technique_ids = {}
+    for s, p, o in g.triples((None, D3F["attack-id"], None)):
+        technique_ids[s] = str(o).strip()
+
+    # Walk subClassOf chain to find tactic
+    technique_to_tactic = {}
+    for uri, tid in technique_ids.items():
+        if not tid.startswith("T"):
+            continue
+        tactics = set()
+        for _, _, parent in g.triples((uri, RDFS.subClassOf, None)):
+            pname = str(parent).split("#")[-1]
+            if pname in TACTIC_CLASSES:
+                tactics.add(TACTIC_CLASSES[pname])
+            for _, _, gp in g.triples((parent, RDFS.subClassOf, None)):
+                gpname = str(gp).split("#")[-1]
+                if gpname in TACTIC_CLASSES:
+                    tactics.add(TACTIC_CLASSES[gpname])
+        if tactics:
+            technique_to_tactic[tid] = tactics
+
+    print(f"[D3FEND-VAL] Loaded tactic mappings for {len(technique_to_tactic)} techniques")
+    return technique_to_tactic
+
+
+# ============================================================
+# VALIDATION GATE
+# ============================================================
+
+def validate_techniques_by_tactic(
+    techniques: list[dict],
+    source_text: str,
+    strict: bool = True,
+) -> list[dict]:
+    """
+    Filter candidate ATT&CK techniques using D3FEND tactic relevance.
+
+    For each candidate technique:
+    1. Look up its tactic classification in D3FEND
+    2. Check if that tactic is evidenced in the source text
+    3. Keep if tactic matches; drop if not (strict mode)
+       or downgrade confidence (non-strict mode)
+
+    This is universal — works for any CTI data, not adversary-specific.
+    The tactic signals come from the actual source text.
+    """
+    if not source_text:
+        return techniques
+
+    technique_tactics = _load_d3fend_technique_tactics()
+    if not technique_tactics:
+        return techniques
+
+    text_tactics = extract_tactic_signals(source_text)
+    if not text_tactics:
+        # Can't determine tactics from text — pass through
+        return techniques
+
+    print(f"[D3FEND-VAL] Detected tactics in text: {sorted(text_tactics)}")
+
+    kept = []
+    dropped = 0
+
+    for tech in techniques:
+        tid = tech.get("id", "")
+        source = tech.get("source", "")
+        tech_tactics = technique_tactics.get(tid, set())
+
+        if not tech_tactics:
+            # Unknown technique in D3FEND — keep it (don't filter what we can't validate)
+            kept.append(tech)
+            continue
+
+        # Check tactic overlap
+        if tech_tactics & text_tactics:
+            # Tactic is relevant to source text — keep
+            kept.append(tech)
+        elif source == "ontology-inference" and strict:
+            # Ontology-inferred technique with irrelevant tactic — drop
+            dropped += 1
+        else:
+            # Non-ontology technique (explicit, semantic) — keep with lower confidence
+            tech = dict(tech)
+            tech["confidence"] = min(tech.get("confidence", 1.0), 0.5)
+            tech["x_d3fend_tactic_mismatch"] = True
+            kept.append(tech)
+
+    print(f"[D3FEND-VAL] kept={len(kept)} dropped={dropped} "
+          f"(text_tactics={len(text_tactics)}, strict={strict})")
+    return kept

--- a/app/utilities/cti_entity_validator.py
+++ b/app/utilities/cti_entity_validator.py
@@ -78,6 +78,65 @@ async def classify_entity_llm(name: str, category: str) -> str:
         return "uncertain"
 
 # ============================================================
+# ENTITY RECLASSIFICATION (DETERMINISTIC, PRE-LLM)
+# ============================================================
+
+def reclassify_entities(ir: dict) -> dict:
+    """
+    Move misclassified entities between IR categories using MITRE taxonomy.
+    Runs BEFORE LLM validation to reduce LLM calls and fix type errors.
+    """
+    groups, malware_names, tool_names = _mitre_name_sets()
+
+    new_malware = []
+    for m in ir.get("malware", []):
+        name = (m.get("name") or "").strip()
+        name_lower = name.lower()
+
+        # Known MITRE tool misclassified as malware → move to tools
+        if name_lower in tool_names:
+            ir.setdefault("tools", []).append(m)
+            print(f"[RECLASS] malware→tool: '{name}' (MITRE taxonomy match)")
+            continue
+
+        # Technique descriptions misclassified as malware → drop from entities
+        technique_indicators = ["deletion", "disabling", "recovery", "clearing",
+                                "modification", "enumeration", "escalation"]
+        if any(ind in name_lower for ind in technique_indicators):
+            print(f"[RECLASS] malware→dropped: '{name}' (technique description)")
+            continue
+
+        # Slash-separated compound names → split
+        if "/" in name and len(name) < 50:
+            parts = [p.strip() for p in name.split("/") if p.strip()]
+            for part in parts:
+                part_lower = part.lower()
+                if part_lower in tool_names:
+                    ir.setdefault("tools", []).append(
+                        {"name": part, "description": m.get("description", "")})
+                    print(f"[RECLASS] split→tool: '{part}'")
+                elif part_lower in malware_names:
+                    new_malware.append(
+                        {"name": part, "description": m.get("description", "")})
+                else:
+                    ir.setdefault("tools", []).append(
+                        {"name": part, "description": m.get("description", "")})
+                    print(f"[RECLASS] split→tool (default): '{part}'")
+            continue
+
+        # Script/executable files → tools
+        if re.search(r'\.(exe|ps1|vbs|dll|bat|cmd)$', name_lower):
+            ir.setdefault("tools", []).append(m)
+            print(f"[RECLASS] malware→tool: '{name}' (script/executable)")
+            continue
+
+        new_malware.append(m)
+
+    ir["malware"] = new_malware
+    return ir
+
+
+# ============================================================
 # ENTITY VALIDATION PIPELINE
 # ============================================================
 
@@ -183,7 +242,7 @@ def repair_entities(ir: dict) -> dict:
 
         name = raw.strip()
         name = name.split(",")[0]                    # remove lists
-        name = re.sub(r"[^A-Za-z0-9 _-]", "", name)  # strip punctuation
+        name = re.sub(r"[^A-Za-z0-9. _-]", "", name)  # strip punctuation, keep dots for IPs/domains
         words = name.split()
 
         # Analyst rule: reject sentence-like entities

--- a/app/utilities/cti_entity_validator.py
+++ b/app/utilities/cti_entity_validator.py
@@ -26,7 +26,38 @@ def _mitre_name_sets():
     groups = {o.get("name","").strip().lower() for o in tax.get("groups", {}).values()}
     malware = {o.get("name","").strip().lower() for o in tax.get("malware", {}).values()}
     tools = {o.get("name","").strip().lower() for o in tax.get("tools", {}).values()}
-    return groups, malware, tools
+    # Also collect aliases for fuzzy matching
+    all_aliases = set()
+    for collection in (tax.get("groups", {}), tax.get("malware", {}), tax.get("tools", {})):
+        for obj in collection.values():
+            for alias in obj.get("x_mitre_aliases", []):
+                all_aliases.add(alias.strip().lower())
+            name = obj.get("name", "").strip().lower()
+            if name:
+                all_aliases.add(name)
+    return groups, malware, tools, all_aliases
+
+
+def _known_cti_entity(name: str) -> bool:
+    """Check if a name is a known CTI entity (tool, malware, or group) by any name/alias."""
+    n = (name or "").strip().lower()
+    if not n or len(n) < 2:
+        return False
+    _, _, _, all_aliases = _mitre_name_sets()
+    # Exact match
+    if n in all_aliases:
+        return True
+    # Common misspellings: try without double letters
+    norm = re.sub(r"(.)\1+", r"\1", n)
+    if norm in all_aliases:
+        return True
+    # Try without trailing version/suffix
+    base = re.sub(r"[.\-_]\w+$", "", n)
+    if base in all_aliases:
+        return True
+    return False
+
+
 async def classify_entity_llm(name: str, category: str) -> str:
     """
     Ask the LLM whether <name> is a valid CTI entity.
@@ -37,13 +68,40 @@ async def classify_entity_llm(name: str, category: str) -> str:
     # Deterministic fast-path (MITRE)
     # -----------------------------
     n = (name or "").strip().lower()
-    groups, malware, tools = _mitre_name_sets()
+    groups, malware, tools, all_aliases = _mitre_name_sets()
 
+    # Exact match in correct category
     if category == "threat_actor" and n in groups:
         return "yes"
     if category == "malware" and n in malware:
         return "yes"
     if category == "tool" and n in tools:
+        return "yes"
+
+    # Cross-category: known entity, just miscategorized → still valid
+    if n in all_aliases:
+        return "yes"
+
+    # Fuzzy: handle misspellings (e.g., "Mimiikatz" → "mimikatz")
+    norm = re.sub(r"(.)\1+", r"\1", n)
+    if norm in all_aliases:
+        return "yes"
+
+    # Common tool names that aren't in MITRE but are widely known
+    WELL_KNOWN = {
+        "anydesk", "teamviewer", "rsync", "wmic", "fsutil", "vim-cmd",
+        "wevtutil", "veeam", "megasync", "rclone", "gmer", "keepass",
+        "winrar", "7zip", "nmap", "netcat", "wget", "curl", "ssh",
+        "scp", "powershell", "cmd.exe", "bitsadmin", "certutil",
+        "vssadmin", "bcdedit", "reg.exe", "sc.exe", "net.exe",
+        "wscript", "cscript", "mshta", "rundll32", "regsvr32",
+        "brute ratel", "sliver", "metasploit", "empire",
+    }
+    if n in WELL_KNOWN or n.rstrip(".exe") in WELL_KNOWN:
+        return "yes"
+
+    # Skip LLM for names that look like file paths or system utilities
+    if re.match(r"^[a-z][a-z0-9._-]{1,20}(\.exe|\.dll|\.ps1|\.vbs|\.bat)?$", n):
         return "yes"
 
     # -----------------------------
@@ -86,7 +144,7 @@ def reclassify_entities(ir: dict) -> dict:
     Move misclassified entities between IR categories using MITRE taxonomy.
     Runs BEFORE LLM validation to reduce LLM calls and fix type errors.
     """
-    groups, malware_names, tool_names = _mitre_name_sets()
+    groups, malware_names, tool_names, _ = _mitre_name_sets()
 
     new_malware = []
     for m in ir.get("malware", []):

--- a/app/utilities/cti_linguistics.py
+++ b/app/utilities/cti_linguistics.py
@@ -19,16 +19,11 @@ NO brittle mappings.
 
 import re
 import numpy as np
-import spacy
 import asyncio
 from rapidfuzz import fuzz
 from functools import lru_cache
 
-# ============================================================
-# NLP MODEL (GLOBAL SINGLE LOAD)
-# ============================================================
-
-nlp = spacy.load("en_core_web_lg")
+from plugins.mcp.app.utilities.nlp_model import nlp
 
 # ===========================================================
 # Attempt to capture command-line invocations

--- a/app/utilities/cti_linguistics.py
+++ b/app/utilities/cti_linguistics.py
@@ -408,7 +408,25 @@ async def extract_dynamic_techniques(text: str, arg2, arg3=None, limit=25, *_, *
             break
 
     out = [t for t in out if t["confidence"] >= 0.80]
-    return out
+
+    # Evidence quality gate: reject matches from short/generic phrases
+    filtered = []
+    for t in out:
+        evidence = t.get("evidence", [""])[0] if t.get("evidence") else ""
+        words = evidence.split()
+        # Require at least 3 content words in the evidence phrase
+        if len(words) < 3:
+            continue
+        # Reject evidence that is all stopwords/generic
+        content_words = [w for w in words if len(w) > 3 and w not in {
+            "that", "this", "with", "from", "into", "also", "such",
+            "been", "have", "were", "will", "used", "using", "more",
+        }]
+        if len(content_words) < 2:
+            continue
+        filtered.append(t)
+
+    return filtered
 
 def _sentencize(text: str) -> list[str]:
     doc = nlp(text or "")

--- a/app/utilities/cti_linguistics.py
+++ b/app/utilities/cti_linguistics.py
@@ -309,7 +309,7 @@ async def _semantic_match_phrase(
             continue
 
         sim = cosine(p_vec, np.asarray(t_vec, dtype=float))
-        dyn_thresh = threshold + 0.15 if len(phrase.split()) <= 2 else threshold
+        dyn_thresh = threshold + 0.08 if len(phrase.split()) <= 2 else threshold
 
         if sim >= dyn_thresh:
             matches.append({
@@ -323,7 +323,7 @@ async def _semantic_match_phrase(
 async def semantic_match_techniques(
         phrases: list[str],
         techniques: list[dict],
-        threshold: float = 0.42
+        threshold: float = 0.82
     ) -> list[dict]:
 
     tasks = [
@@ -407,7 +407,7 @@ async def extract_dynamic_techniques(text: str, arg2, arg3=None, limit=25, *_, *
         if len(out) >= limit:
             break
 
-    out = [t for t in out if t["confidence"] >= 0.18]
+    out = [t for t in out if t["confidence"] >= 0.80]
     return out
 
 def _sentencize(text: str) -> list[str]:

--- a/app/utilities/cti_mitre_extract.py
+++ b/app/utilities/cti_mitre_extract.py
@@ -14,18 +14,12 @@ This module performs NO orchestration.
 
 import re
 import numpy as np
-import spacy
 from datetime import datetime
 import uuid
 from functools import lru_cache
 from spacy.lang.en.stop_words import STOP_WORDS as SPACY_STOP_WORDS
 
-
-# ============================================================
-# NLP MODEL (GLOBAL SINGLE LOAD)
-# ============================================================
-
-nlp = spacy.load("en_core_web_lg")
+from plugins.mcp.app.utilities.nlp_model import nlp
 
 
 # ============================================================

--- a/app/utilities/cti_offline_ir.py
+++ b/app/utilities/cti_offline_ir.py
@@ -134,6 +134,51 @@ def extract_ir_offline(text: str) -> dict:
                     "source": "mitre-taxonomy",
                 })
 
+    # Promote malware that acts as actor names in text
+    # (e.g., "BlackCat exploits..." → BlackCat is also an actor)
+    doc = nlp(text[:nlp.max_length])
+    malware_names = {m["name"].lower() for m in ir["malware"]}
+
+    for sent in doc.sents:
+        root = sent.root
+        if root.pos_ != "VERB":
+            continue
+        # Check if subject is a known malware name used as agent
+        for child in root.children:
+            if child.dep_ in ("nsubj", "nsubjpass"):
+                subj = child.text.strip().lower()
+                if subj in malware_names or any(subj in m for m in malware_names):
+                    # This malware is used as an actor in the text
+                    for m in ir["malware"]:
+                        if subj in m["name"].lower():
+                            actor_key = ("threat_actors", m["name"].lower())
+                            if actor_key not in seen_entities:
+                                seen_entities.add(actor_key)
+                                ir["threat_actors"].append({
+                                    "name": m["name"],
+                                    "description": f"Threat actor (inferred from malware name used as agent)",
+                                    "source": "agent-inference",
+                                })
+                            break
+
+    # Also add actors from title-case proper nouns near attack verbs
+    ATTACK_VERBS = {"exploit", "deploy", "execute", "target", "compromise",
+                    "attack", "encrypt", "exfiltrate", "disable", "leverage"}
+    for sent in doc.sents:
+        for tok in sent:
+            if tok.lemma_.lower() in ATTACK_VERBS:
+                for child in tok.children:
+                    if child.dep_ == "nsubj" and child.text[0].isupper():
+                        name = child.text.strip()
+                        key = ("threat_actors", name.lower())
+                        if key not in seen_entities and len(name) > 2:
+                            seen_entities.add(key)
+                            ir["threat_actors"].append({
+                                "name": name,
+                                "description": "",
+                                "source": "verb-agent-inference",
+                            })
+
     mitre_found = sum(len(ir[k]) for k in ("threat_actors", "malware", "tools"))
     print(f"[OFFLINE-IR] MITRE taxonomy matches: {mitre_found}")
 

--- a/app/utilities/cti_offline_ir.py
+++ b/app/utilities/cti_offline_ir.py
@@ -1,0 +1,306 @@
+"""
+cti_offline_ir.py — Offline IR Extraction (No LLM Required)
+
+Produces the same IR schema as cti_parsing.py but using only:
+- spaCy NER for entity extraction
+- MITRE ATT&CK taxonomy for entity classification
+- Regex patterns for IOCs, T-numbers, tool names
+- spaCy dependency parsing for behavior extraction
+
+This is the "fast mode" / "offline mode" alternative to LLM-based
+IR extraction. Trades ~15-20% recall for sub-second processing.
+"""
+
+import re
+from functools import lru_cache
+
+from plugins.mcp.app.utilities.nlp_model import nlp
+from plugins.mcp.app.utilities.cti_linguistics import extract_hashes, extract_commands
+
+
+# ============================================================
+# MITRE ENTITY LOOKUP
+# ============================================================
+
+@lru_cache(maxsize=1)
+def _build_mitre_entity_index():
+    """
+    Build a case-insensitive index of all MITRE-known entity names.
+    Returns: {lowercase_name: (category, name, description)}
+    """
+    from plugins.mcp.app.utilities.cti_taxonomy_loader import load_mitre_taxonomy
+    tax = load_mitre_taxonomy()
+
+    index = {}
+
+    for obj_id, obj in tax.get("tools", {}).items():
+        name = obj.get("name", "").strip()
+        desc = obj.get("description", "")[:200] if obj.get("description") else ""
+        if name:
+            index[name.lower()] = ("tools", name, desc)
+            for alias in obj.get("x_mitre_aliases", []):
+                index[alias.lower()] = ("tools", alias, desc)
+
+    for obj_id, obj in tax.get("malware", {}).items():
+        name = obj.get("name", "").strip()
+        desc = obj.get("description", "")[:200] if obj.get("description") else ""
+        if name:
+            index[name.lower()] = ("malware", name, desc)
+            for alias in obj.get("x_mitre_aliases", []):
+                index[alias.lower()] = ("malware", alias, desc)
+
+    for obj_id, obj in tax.get("groups", {}).items():
+        name = obj.get("name", "").strip()
+        desc = obj.get("description", "")[:200] if obj.get("description") else ""
+        if name:
+            index[name.lower()] = ("threat_actors", name, desc)
+            for alias in obj.get("x_mitre_aliases", []):
+                index[alias.lower()] = ("threat_actors", alias, desc)
+
+    return index
+
+
+# ============================================================
+# WELL-KNOWN CTI ENTITY PATTERNS
+# ============================================================
+
+# Tools commonly seen in CTI that may not be in MITRE taxonomy
+WELL_KNOWN_TOOLS = {
+    "anydesk", "teamviewer", "megasync", "rclone", "winrar", "7zip",
+    "winscp", "filezilla", "ngrok", "chisel", "ligolo", "rsync",
+    "veeam", "acronis", "nmap", "masscan", "advanced ip scanner",
+    "sharphound", "bloodhound", "rubeus", "seatbelt", "certutil",
+    "bitsadmin", "wevtutil", "bcdedit", "vssadmin", "fsutil",
+    "wmic", "net.exe", "sc.exe", "reg.exe", "tasklist",
+    "procdump", "dumpert", "nanodump", "ppldump",
+}
+
+# Infrastructure patterns (regex)
+INFRA_PATTERNS = [
+    (r"\b(?:\d{1,3}\.){3}\d{1,3}\b", "IPv4 address"),
+    (r"\b[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.[a-z]{2,}\b", "domain"),
+    (r"\b(?:https?://\S+)\b", "URL"),
+]
+
+
+# ============================================================
+# OFFLINE IR EXTRACTION
+# ============================================================
+
+def extract_ir_offline(text: str) -> dict:
+    """
+    Extract IR from CTI text without any LLM calls.
+
+    Uses:
+    1. spaCy NER for organizations and named entities
+    2. MITRE taxonomy matching for tool/malware/group classification
+    3. Regex for IOCs and infrastructure
+    4. spaCy dependency parsing for behaviors
+
+    Returns the same schema as cti_parsing.extract_ir().
+    """
+    print("[OFFLINE-IR] Starting offline extraction")
+
+    mitre_index = _build_mitre_entity_index()
+
+    ir = {
+        "threat_actors": [],
+        "malware": [],
+        "tools": [],
+        "infrastructure": [],
+        "attack_patterns": [],
+        "behaviors": [],
+        "relationships": [],
+    }
+
+    seen_entities = set()
+    text_lower = text.lower()
+
+    # ---------------------------------------------------------
+    # 1. MITRE taxonomy scan — find known entities in text
+    # ---------------------------------------------------------
+    for name_lower, (category, canonical_name, desc) in mitre_index.items():
+        if len(name_lower) < 3:
+            continue
+        # Require word boundary match to avoid substring false positives
+        pattern = r"\b" + re.escape(name_lower) + r"\b"
+        if re.search(pattern, text_lower):
+            key = (category, canonical_name.lower())
+            if key not in seen_entities:
+                seen_entities.add(key)
+                ir[category].append({
+                    "name": canonical_name,
+                    "description": desc,
+                    "source": "mitre-taxonomy",
+                })
+
+    mitre_found = sum(len(ir[k]) for k in ("threat_actors", "malware", "tools"))
+    print(f"[OFFLINE-IR] MITRE taxonomy matches: {mitre_found}")
+
+    # ---------------------------------------------------------
+    # 2. Well-known tools scan
+    # ---------------------------------------------------------
+    for tool in WELL_KNOWN_TOOLS:
+        pattern = r"\b" + re.escape(tool) + r"\b"
+        if re.search(pattern, text_lower):
+            key = ("tools", tool)
+            if key not in seen_entities:
+                seen_entities.add(key)
+                # Find the sentence containing the tool for description
+                for sent in text.split("."):
+                    if tool in sent.lower():
+                        desc = sent.strip()[:150]
+                        break
+                else:
+                    desc = ""
+                ir["tools"].append({
+                    "name": tool.title() if not any(c.isupper() for c in tool) else tool,
+                    "description": desc,
+                    "source": "well-known",
+                })
+
+    # ---------------------------------------------------------
+    # 3. spaCy NER — catch entities MITRE/well-known missed
+    # ---------------------------------------------------------
+    doc = nlp(text[:nlp.max_length])
+
+    for ent in doc.ents:
+        if ent.label_ in ("ORG", "PRODUCT"):
+            name = ent.text.strip()
+            if len(name) < 3 or len(name) > 40:
+                continue
+            # Skip if already found
+            name_lower_ent = name.lower()
+            if any(name_lower_ent in k[1] for k in seen_entities):
+                continue
+            # Check if it looks like a CTI entity (not a media company, etc.)
+            if _is_likely_cti_entity(name, text):
+                key = ("tools", name_lower_ent)
+                if key not in seen_entities:
+                    seen_entities.add(key)
+                    ir["tools"].append({
+                        "name": name,
+                        "description": "",
+                        "source": "spacy-ner",
+                    })
+
+    # ---------------------------------------------------------
+    # 4. Infrastructure extraction (regex)
+    # ---------------------------------------------------------
+    for pattern, infra_type in INFRA_PATTERNS:
+        for match in re.finditer(pattern, text):
+            value = match.group(0)
+            # Skip common false positives
+            if infra_type == "domain" and value in ("example.com", "attack.mitre.org"):
+                continue
+            if infra_type == "IPv4 address" and value.startswith(("0.", "127.", "255.")):
+                continue
+            key = ("infrastructure", value.lower())
+            if key not in seen_entities:
+                seen_entities.add(key)
+                ir["infrastructure"].append({
+                    "name": value,
+                    "description": infra_type,
+                    "source": "regex",
+                })
+
+    # ---------------------------------------------------------
+    # 5. Behavior extraction (spaCy dependency parsing)
+    # ---------------------------------------------------------
+    for sent in doc.sents:
+        root = sent.root
+        if root.pos_ != "VERB":
+            continue
+
+        # Skip reporter verbs
+        if root.lemma_.lower() in {
+            "report", "describe", "note", "observe", "identify",
+            "analyze", "assess", "document", "publish", "state",
+        }:
+            continue
+
+        # Extract verb + object
+        obj = None
+        for child in root.children:
+            if child.dep_ in ("dobj", "pobj", "attr"):
+                obj = " ".join(t.text for t in child.subtree).strip()
+                break
+
+        if obj and len(obj) > 5:
+            behavior = f"{root.lemma_} {obj}"
+            ir["behaviors"].append({
+                "description": behavior,
+                "source": "spacy-dep",
+            })
+
+    # Dedupe behaviors by content
+    seen_beh = set()
+    unique_beh = []
+    for b in ir["behaviors"]:
+        key = b["description"].lower()
+        if key not in seen_beh:
+            seen_beh.add(key)
+            unique_beh.append(b)
+    ir["behaviors"] = unique_beh[:20]  # Cap at 20
+
+    # ---------------------------------------------------------
+    # 6. Attack pattern extraction from text
+    # ---------------------------------------------------------
+    # These are attack descriptions, not MITRE IDs (those come later)
+    attack_indicators = [
+        (r"(?:exploit|leverage)\w*\s+(?:vulnerabilit|CVE|flaw)\w*[^.]*", "vulnerability exploitation"),
+        (r"(?:lateral\s+movement|move\s+laterally)[^.]*", "lateral movement"),
+        (r"(?:exfiltrat|steal|theft)[^.]*data[^.]*", "data exfiltration"),
+        (r"(?:encrypt|ransom)\w*[^.]*files?[^.]*", "file encryption"),
+        (r"(?:credential|password)\s+(?:dump|harvest|steal|extract)[^.]*", "credential access"),
+        (r"(?:disable|tamper|bypass)\w*\s+(?:security|defender|antivirus|av)[^.]*", "defense evasion"),
+        (r"(?:shadow\s+cop(?:y|ies)|vssadmin)[^.]*(?:delet|remov)[^.]*", "recovery inhibition"),
+        (r"(?:registry|reg\.exe)\s+(?:modif|set|add|change)[^.]*", "registry modification"),
+        (r"(?:scheduled?\s+task|cron|at\s+job)[^.]*", "scheduled execution"),
+    ]
+
+    for pattern, label in attack_indicators:
+        matches = re.finditer(pattern, text, re.IGNORECASE)
+        for m in matches:
+            ir["attack_patterns"].append({
+                "description": m.group(0).strip()[:200],
+                "source": "regex-pattern",
+            })
+            break  # One match per pattern
+
+    total = sum(len(ir[k]) for k in ir if isinstance(ir[k], list))
+    print(f"[OFFLINE-IR] Total entities: {total} "
+          f"(actors={len(ir['threat_actors'])} malware={len(ir['malware'])} "
+          f"tools={len(ir['tools'])} infra={len(ir['infrastructure'])} "
+          f"behaviors={len(ir['behaviors'])} patterns={len(ir['attack_patterns'])})")
+
+    return ir
+
+
+def _is_likely_cti_entity(name: str, context: str) -> bool:
+    """
+    Heuristic: is this spaCy NER entity likely a CTI-relevant tool/malware?
+    """
+    name_lower = name.lower()
+
+    # Skip common non-CTI organizations
+    SKIP = {
+        "palo alto", "symantec", "microsoft", "sophos", "cisco",
+        "trend micro", "kroll", "group-ib", "varonis", "unit 42",
+        "talos", "mitre", "nist",
+    }
+    for skip in SKIP:
+        if skip in name_lower:
+            return False
+
+    # CTI-relevant if near attack-related words
+    context_lower = context.lower()
+    idx = context_lower.find(name_lower)
+    if idx >= 0:
+        window = context_lower[max(0, idx - 100):idx + len(name) + 100]
+        cti_cues = ["malware", "tool", "ransomware", "exploit", "attack",
+                    "deploy", "execute", "lateral", "credential", "encrypt"]
+        if any(cue in window for cue in cti_cues):
+            return True
+
+    return False

--- a/app/utilities/cti_offline_ir.py
+++ b/app/utilities/cti_offline_ir.py
@@ -134,50 +134,63 @@ def extract_ir_offline(text: str) -> dict:
                     "source": "mitre-taxonomy",
                 })
 
-    # Promote malware that acts as actor names in text
-    # (e.g., "BlackCat exploits..." → BlackCat is also an actor)
-    doc = nlp(text[:nlp.max_length])
-    malware_names = {m["name"].lower() for m in ir["malware"]}
+    # ---------------------------------------------------------
+    # Actor inference: use MITRE entity frequency + title + first paragraph
+    # The most frequently mentioned MITRE malware/group is the primary actor
+    # ---------------------------------------------------------
+    from collections import Counter as _Counter
 
-    for sent in doc.sents:
-        root = sent.root
-        if root.pos_ != "VERB":
+    # Get MITRE malware and group names
+    malware_set = set()
+    group_set = set()
+    for obj in mitre_index.values():
+        cat = obj[0]
+        name = obj[1].lower()
+        if cat == "malware":
+            malware_set.add(name)
+        elif cat == "threat_actors":
+            group_set.add(name)
+
+    # Count frequency of each MITRE malware/group in the text
+    actor_freq = _Counter()
+    for name in (malware_set | group_set):
+        if len(name) < 3:
             continue
-        # Check if subject is a known malware name used as agent
-        for child in root.children:
-            if child.dep_ in ("nsubj", "nsubjpass"):
-                subj = child.text.strip().lower()
-                if subj in malware_names or any(subj in m for m in malware_names):
-                    # This malware is used as an actor in the text
-                    for m in ir["malware"]:
-                        if subj in m["name"].lower():
-                            actor_key = ("threat_actors", m["name"].lower())
-                            if actor_key not in seen_entities:
-                                seen_entities.add(actor_key)
-                                ir["threat_actors"].append({
-                                    "name": m["name"],
-                                    "description": f"Threat actor (inferred from malware name used as agent)",
-                                    "source": "agent-inference",
-                                })
-                            break
+        pattern = r"\b" + re.escape(name) + r"\b"
+        count = len(re.findall(pattern, text_lower))
+        if count > 0:
+            actor_freq[name] = count
 
-    # Also add actors from title-case proper nouns near attack verbs
-    ATTACK_VERBS = {"exploit", "deploy", "execute", "target", "compromise",
-                    "attack", "encrypt", "exfiltrate", "disable", "leverage"}
-    for sent in doc.sents:
-        for tok in sent:
-            if tok.lemma_.lower() in ATTACK_VERBS:
-                for child in tok.children:
-                    if child.dep_ == "nsubj" and child.text[0].isupper():
-                        name = child.text.strip()
-                        key = ("threat_actors", name.lower())
-                        if key not in seen_entities and len(name) > 2:
-                            seen_entities.add(key)
-                            ir["threat_actors"].append({
-                                "name": name,
-                                "description": "",
-                                "source": "verb-agent-inference",
-                            })
+    # Title bonus: entities in the first line get a boost
+    first_line = text.strip().split("\n")[0].lower()
+    for name in actor_freq:
+        if name in first_line:
+            actor_freq[name] += 3  # title mention is strong signal
+
+    # First paragraph bonus
+    first_para = text.strip().split("\n\n")[0].lower() if "\n\n" in text else text_lower[:500]
+    for name in actor_freq:
+        if name in first_para:
+            actor_freq[name] += 1
+
+    # Add top actors (by frequency) that aren't already in IR
+    for name, count in actor_freq.most_common(3):
+        if count < 2:
+            continue
+        key = ("threat_actors", name)
+        if key not in seen_entities:
+            seen_entities.add(key)
+            # Find canonical name from index
+            canonical = name
+            for idx_name, (cat, canon, desc) in mitre_index.items():
+                if idx_name == name:
+                    canonical = canon
+                    break
+            ir["threat_actors"].append({
+                "name": canonical,
+                "description": f"Primary threat actor ({count} mentions)",
+                "source": "frequency-inference",
+            })
 
     mitre_found = sum(len(ir[k]) for k in ("threat_actors", "malware", "tools"))
     print(f"[OFFLINE-IR] MITRE taxonomy matches: {mitre_found}")

--- a/app/utilities/cti_ontology_inference.py
+++ b/app/utilities/cti_ontology_inference.py
@@ -1,0 +1,176 @@
+"""
+cti_ontology_inference.py — Ontology-Driven Technique Inference
+
+Infers ATT&CK techniques from known tools/malware using the MITRE
+taxonomy relationship graph. Zero LLM. Zero network. Pure ontology.
+
+This implements the "senior analyst shortcut":
+    "I see Mimikatz → therefore T1003.001 (LSASS Memory)"
+
+Data source: enterprise_attack.json (50MB, already local)
+Contains: 20,048 relationships mapping tools/malware → techniques
+"""
+
+import re
+from functools import lru_cache
+from plugins.mcp.app.utilities.cti_taxonomy_loader import load_mitre_taxonomy
+
+
+@lru_cache(maxsize=1)
+def _build_entity_technique_map():
+    """
+    Build a mapping: normalized entity name → list of ATT&CK technique IDs.
+
+    Uses MITRE relationships where:
+        source = tool/malware (STIX ID)
+        relationship_type = "uses"
+        target = attack-pattern (STIX ID)
+    """
+    tax = load_mitre_taxonomy()
+    rels = tax["relationships"]
+    tools_by_id = tax["tools"]
+    malware_by_id = tax["malware"]
+    ap_by_id = tax["attack_patterns"]
+    attack_id_idx = tax["attack_id_index"]
+
+    # Step 1: Map entity names (including aliases) → STIX ID
+    name_to_stix_id = {}
+    for obj_id, obj in tools_by_id.items():
+        n = obj.get("name", "").lower().strip()
+        if n:
+            name_to_stix_id[n] = obj_id
+        for alias in obj.get("x_mitre_aliases", []):
+            name_to_stix_id[alias.lower().strip()] = obj_id
+
+    for obj_id, obj in malware_by_id.items():
+        n = obj.get("name", "").lower().strip()
+        if n:
+            name_to_stix_id[n] = obj_id
+        for alias in obj.get("x_mitre_aliases", []):
+            name_to_stix_id[alias.lower().strip()] = obj_id
+
+    # Step 2: Map STIX ID → technique IDs via "uses" relationships
+    stix_id_to_techniques = {}
+    for r in rels:
+        if r.get("relationship_type") != "uses":
+            continue
+        src = r.get("source_ref", "")
+        tgt = r.get("target_ref", "")
+        if not tgt.startswith("attack-pattern"):
+            continue
+
+        ap = ap_by_id.get(tgt)
+        if not ap:
+            continue
+
+        tid = None
+        for ref in ap.get("external_references", []):
+            if ref.get("source_name") == "mitre-attack":
+                tid = ref.get("external_id")
+                break
+        if not tid:
+            continue
+
+        stix_id_to_techniques.setdefault(src, []).append(tid)
+
+    # Step 3: Combine into name → technique IDs
+    entity_to_techniques = {}
+    for name, stix_id in name_to_stix_id.items():
+        techs = stix_id_to_techniques.get(stix_id, [])
+        if techs:
+            entity_to_techniques[name] = techs
+
+    return entity_to_techniques, name_to_stix_id
+
+
+def infer_techniques_from_entities(
+    ir: dict, lookup: dict, source_text: str = ""
+) -> list[dict]:
+    """
+    Given an IR with tools/malware, infer ATT&CK techniques from the
+    MITRE taxonomy relationship graph.
+
+    When source_text is provided, techniques are filtered to those
+    corroborated by the source text (keyword overlap with technique
+    name or description). This prevents tools with broad technique
+    profiles (e.g., Cobalt Strike → 72 techniques) from flooding
+    the output with irrelevant matches.
+
+    Returns technique objects compatible with the pipeline's attack_patterns format.
+    Only returns techniques that exist in the current taxonomy (lookup dict).
+    """
+    entity_map, _ = _build_entity_technique_map()
+
+    # Collect all entity names from IR
+    entity_names = set()
+    for group in ("tools", "malware"):
+        for ent in ir.get(group, []):
+            name = (ent.get("name") or "").strip().lower()
+            if name:
+                entity_names.add(name)
+
+    # Build source text token set for corroboration
+    source_tokens = set()
+    if source_text:
+        source_tokens = set(re.findall(r"[a-z]{3,}", source_text.lower()))
+
+    # Infer techniques
+    inferred = {}
+    skipped_no_corroboration = 0
+
+    for name in entity_names:
+        techniques = entity_map.get(name, [])
+        if not techniques:
+            norm = re.sub(r"[^a-z0-9 ]", "", name).strip()
+            techniques = entity_map.get(norm, [])
+
+        # Tools with broad profiles (>8 techniques) require text corroboration
+        needs_corroboration = len(techniques) > 8 and bool(source_tokens)
+
+        for tid in techniques:
+            if tid not in lookup:
+                continue
+
+            tech = lookup[tid]
+
+            if needs_corroboration:
+                # Check if technique name or description keywords overlap
+                # with the source text
+                tech_name = (tech.get("name", "") or "").lower()
+                tech_desc = (tech.get("description", "") or "").lower()
+                tech_tokens = set(re.findall(r"[a-z]{4,}", tech_name))
+                tech_tokens |= set(re.findall(r"[a-z]{5,}", tech_desc))
+                # Remove very common words
+                tech_tokens -= {
+                    "attack", "which", "these", "those", "their",
+                    "other", "about", "after", "before", "being",
+                    "could", "would", "should", "through", "using",
+                    "example", "information", "techniques", "adversaries",
+                    "system", "systems", "command", "commands",
+                }
+
+                overlap = tech_tokens & source_tokens
+                if len(overlap) < 3:
+                    skipped_no_corroboration += 1
+                    continue
+
+            if tid not in inferred:
+                inferred[tid] = {
+                    "id": tid,
+                    "name": tech.get("name", ""),
+                    "confidence": 0.90,
+                    "evidence": [f"MITRE taxonomy: {name} uses {tid}"],
+                    "source": "ontology-inference",
+                }
+            else:
+                inferred[tid]["evidence"].append(
+                    f"MITRE taxonomy: {name} uses {tid}")
+                inferred[tid]["confidence"] = min(
+                    inferred[tid]["confidence"] + 0.03, 0.97)
+
+    results = list(inferred.values())
+    print(f"[ONTOLOGY] entities={len(entity_names)} "
+          f"inferred={len(results)} "
+          f"skipped_no_corroboration={skipped_no_corroboration}")
+
+    return results

--- a/app/utilities/cti_precision_gate.py
+++ b/app/utilities/cti_precision_gate.py
@@ -1,0 +1,407 @@
+"""
+cti_precision_gate.py — Unified Precision Gate for ATT&CK Techniques
+
+Combines multiple non-ML methods to filter false positive techniques:
+
+1. PMI Co-occurrence: measures statistical association between technique
+   keywords and the source text within document windows
+2. Sub-technique Hierarchy: enforces ATT&CK parent↔child consistency
+3. Entity-Technique Clique: requires mutual corroboration between
+   co-occurring entities and their inferred techniques
+4. TF-IDF Evidence Scoring: weights technique evidence by term
+   specificity to reject generic matches
+
+All methods use only local data (MITRE taxonomy, D3FEND ontology,
+source text). No ML, no LLM, no network.
+"""
+
+import re
+import math
+from collections import Counter, defaultdict
+from functools import lru_cache
+
+
+# ============================================================
+# 1. PMI CO-OCCURRENCE FILTERING
+# ============================================================
+
+def _build_document_term_counts(text: str, window_size: int = 200) -> dict:
+    """
+    Build term frequency map from document using sliding windows.
+    Returns: {term: count_of_windows_containing_term}
+    """
+    words = re.findall(r"[a-z]{3,}", text.lower())
+    total_windows = max(1, len(words) - window_size + 1)
+
+    term_window_count = Counter()
+    for i in range(0, len(words), window_size // 2):  # 50% overlap
+        window = set(words[i:i + window_size])
+        for w in window:
+            term_window_count[w] += 1
+
+    return term_window_count, total_windows
+
+
+def compute_pmi(term_a_count: int, term_b_count: int,
+                cooccurrence_count: int, total_windows: int) -> float:
+    """
+    Pointwise Mutual Information between two terms.
+    PMI(a,b) = log2(P(a,b) / (P(a) * P(b)))
+    """
+    if cooccurrence_count == 0 or total_windows == 0:
+        return 0.0
+
+    p_a = term_a_count / total_windows
+    p_b = term_b_count / total_windows
+    p_ab = cooccurrence_count / total_windows
+
+    if p_a == 0 or p_b == 0:
+        return 0.0
+
+    return math.log2(p_ab / (p_a * p_b))
+
+
+def pmi_score_technique(technique: dict, text: str,
+                        term_counts: dict, total_windows: int,
+                        window_size: int = 200) -> float:
+    """
+    Score a technique by PMI between its key terms and the source text.
+    High PMI = technique terms genuinely co-occur with report content.
+    Low PMI = spurious association.
+    """
+    # Extract technique signature terms from name + description
+    tech_name = (technique.get("name") or "").lower()
+    tech_desc = (technique.get("description") or "").lower()
+
+    # Use technique name terms (most discriminative)
+    tech_terms = set(re.findall(r"[a-z]{4,}", tech_name))
+    # Add a few description terms (nouns/verbs only, skip common words)
+    desc_terms = set(re.findall(r"[a-z]{5,}", tech_desc))
+    STOPWORDS = {
+        "which", "these", "those", "their", "other", "about", "after",
+        "before", "being", "could", "would", "should", "through", "using",
+        "example", "information", "techniques", "adversaries", "adversary",
+        "system", "systems", "command", "commands", "within", "against",
+        "between", "during", "access", "perform", "including", "specific",
+    }
+    desc_terms -= STOPWORDS
+
+    # Combine, prioritizing name terms
+    sig_terms = tech_terms | (desc_terms - tech_terms)
+    if not sig_terms:
+        return 0.0
+
+    words = re.findall(r"[a-z]{3,}", text.lower())
+
+    # Find co-occurrence windows between entity evidence and technique terms
+    best_pmi = 0.0
+    for term in sig_terms:
+        term_count = term_counts.get(term, 0)
+        if term_count == 0:
+            continue
+
+        # Check co-occurrence with the entity that triggered this technique
+        evidence = technique.get("evidence", [])
+        entity_terms = set()
+        for ev in evidence:
+            if "MITRE taxonomy:" in str(ev):
+                entity = str(ev).split("MITRE taxonomy:")[1].split("uses")[0].strip()
+                entity_terms.update(re.findall(r"[a-z]{3,}", entity.lower()))
+
+        for et in entity_terms:
+            et_count = term_counts.get(et, 0)
+            if et_count == 0:
+                continue
+
+            # Count windows where both appear
+            cooccur = 0
+            for i in range(0, len(words), window_size // 2):
+                window = set(words[i:i + window_size])
+                if term in window and et in window:
+                    cooccur += 1
+
+            pmi = compute_pmi(et_count, term_count, cooccur, total_windows)
+            best_pmi = max(best_pmi, pmi)
+
+    return best_pmi
+
+
+# ============================================================
+# 2. SUB-TECHNIQUE HIERARCHY ENFORCEMENT
+# ============================================================
+
+def enforce_hierarchy(techniques: list[dict]) -> list[dict]:
+    """
+    Enforce ATT&CK parent↔sub-technique consistency.
+
+    Rules:
+    - If sub-technique T1078.002 exists, parent T1078 is implied (add it)
+    - Orphan sub-techniques with no sibling or parent support get
+      confidence downgrade
+    """
+    tid_set = {t.get("id") for t in techniques if t.get("id")}
+
+    # Build parent→children map
+    parents = defaultdict(set)
+    for tid in tid_set:
+        if "." in tid:
+            parent = tid.split(".")[0]
+            parents[parent].add(tid)
+
+    # Score: sub-techniques with siblings are stronger
+    hierarchy_scores = {}
+    for parent, children in parents.items():
+        for child in children:
+            # More siblings = more confidence
+            hierarchy_scores[child] = min(len(children) / 3.0, 1.0)
+
+    # Apply: downgrade orphan sub-techniques from ontology inference
+    result = []
+    for t in techniques:
+        tid = t.get("id", "")
+        if "." in tid and tid in hierarchy_scores:
+            if hierarchy_scores[tid] < 0.34:  # only child, no siblings
+                if t.get("source") == "ontology-inference":
+                    t = dict(t)
+                    t["confidence"] = min(t.get("confidence", 1.0), 0.6)
+                    t["x_hierarchy_orphan"] = True
+        result.append(t)
+
+    return result
+
+
+# ============================================================
+# 3. ENTITY-TECHNIQUE CLIQUE CORROBORATION
+# ============================================================
+
+def clique_filter(techniques: list[dict], ir: dict) -> list[dict]:
+    """
+    Entity-technique clique corroboration.
+
+    Principle: techniques inferred from multiple co-occurring entities
+    are more likely correct than techniques from a single entity.
+
+    A technique supported by 2+ entities in the same report gets a
+    confidence boost. A technique from only one entity (especially
+    a broad-profile one) gets downgraded.
+    """
+    # Count how many distinct entities support each technique
+    technique_entity_support = defaultdict(set)
+    for t in techniques:
+        tid = t.get("id", "")
+        for ev in (t.get("evidence") or []):
+            if "MITRE taxonomy:" in str(ev):
+                entity = str(ev).split("MITRE taxonomy:")[1].split("uses")[0].strip()
+                technique_entity_support[tid].add(entity)
+
+    # Also count entities in the IR
+    all_entities = set()
+    for group in ("tools", "malware"):
+        for ent in ir.get(group, []):
+            name = (ent.get("name") or "").strip().lower()
+            if name:
+                all_entities.add(name)
+
+    result = []
+    for t in techniques:
+        tid = t.get("id", "")
+        supporters = technique_entity_support.get(tid, set())
+
+        if t.get("source") != "ontology-inference":
+            # Non-ontology techniques pass through
+            result.append(t)
+            continue
+
+        if len(supporters) >= 2:
+            # Multi-entity support = strong signal, boost confidence
+            t = dict(t)
+            t["confidence"] = min(t.get("confidence", 0.9) + 0.05, 0.97)
+            t["x_clique_support"] = len(supporters)
+            result.append(t)
+        elif len(supporters) == 1:
+            # Single entity support — check if that entity is broad-profile
+            entity = list(supporters)[0]
+            entity_techniques = [
+                t2 for t2 in techniques
+                if t2.get("source") == "ontology-inference"
+                and any(entity in str(e) for e in (t2.get("evidence") or []))
+            ]
+            if len(entity_techniques) > 15:
+                # Broad-profile entity — mark but don't drop
+                t = dict(t)
+                t["x_broad_profile_entity"] = entity
+                t["x_broad_profile_count"] = len(entity_techniques)
+            result.append(t)
+        else:
+            result.append(t)
+
+    return result
+
+
+# ============================================================
+# 4. TF-IDF EVIDENCE SCORING
+# ============================================================
+
+def tfidf_score_evidence(technique: dict, text: str,
+                         corpus_term_freq: dict) -> float:
+    """
+    Score technique evidence using TF-IDF principles.
+
+    High score = evidence terms are frequent in THIS document
+    but rare across general text (discriminative).
+    Low score = evidence terms are generic/common.
+    """
+    evidence = technique.get("evidence", [])
+    if not evidence:
+        return 0.0
+
+    doc_words = re.findall(r"[a-z]{3,}", text.lower())
+    doc_tf = Counter(doc_words)
+    doc_len = max(len(doc_words), 1)
+
+    total_score = 0.0
+    term_count = 0
+
+    for ev in evidence:
+        ev_str = str(ev)
+        # Skip MITRE taxonomy evidence strings — score only text evidence
+        if "MITRE taxonomy:" in ev_str:
+            continue
+
+        ev_terms = set(re.findall(r"[a-z]{4,}", ev_str.lower()))
+        for term in ev_terms:
+            tf = doc_tf.get(term, 0) / doc_len
+            # IDF approximation: rare terms in general English score higher
+            idf = corpus_term_freq.get(term, 1.0)
+            total_score += tf * idf
+            term_count += 1
+
+    return total_score / max(term_count, 1)
+
+
+# General English IDF approximations for common CTI terms
+# Higher = more discriminative (rarer in general text)
+# Lower = more common (less useful for precision)
+_GENERAL_IDF = {
+    # Very common (low IDF) — these don't help distinguish techniques
+    "system": 0.5, "process": 0.6, "access": 0.5, "data": 0.4,
+    "file": 0.6, "network": 0.6, "service": 0.5, "user": 0.5,
+    "information": 0.3, "application": 0.4, "security": 0.5,
+    "tool": 0.5, "technique": 0.4, "attack": 0.6,
+    # Moderately discriminative
+    "credential": 1.5, "registry": 1.5, "executable": 1.5,
+    "encryption": 1.5, "lateral": 2.0, "exfiltration": 2.0,
+    "privilege": 1.5, "persistence": 1.8, "evasion": 1.8,
+    # Highly discriminative (high IDF)
+    "lsass": 3.0, "mimikatz": 3.0, "psexec": 3.0, "vssadmin": 3.0,
+    "ransomware": 2.5, "keylogger": 3.0, "shellcode": 3.0,
+    "powershell": 2.0, "wmic": 2.5, "bcdedit": 3.0,
+    "kerberos": 2.5, "ntlm": 2.5, "rdp": 2.0,
+}
+
+
+def get_idf(term: str) -> float:
+    """Get IDF approximation for a term. Default 1.0 for unknown terms."""
+    return _GENERAL_IDF.get(term, 1.0)
+
+
+# ============================================================
+# UNIFIED PRECISION GATE
+# ============================================================
+
+def apply_precision_gate(
+    techniques: list[dict],
+    source_text: str,
+    ir: dict,
+    min_confidence: float = 0.50,
+) -> list[dict]:
+    """
+    Unified precision gate combining all methods.
+
+    Pipeline:
+    1. Hierarchy enforcement (structural)
+    2. Clique corroboration (entity-level)
+    3. PMI co-occurrence scoring (statistical)
+    4. Confidence threshold (final cut)
+
+    Techniques below min_confidence after all scoring are dropped.
+    """
+    if not techniques:
+        return techniques
+
+    print(f"[PRECISION] Input: {len(techniques)} techniques")
+
+    # --- 1. Hierarchy enforcement ---
+    techniques = enforce_hierarchy(techniques)
+
+    # --- 2. Clique corroboration ---
+    techniques = clique_filter(techniques, ir)
+
+    # --- 3. PMI co-occurrence for ontology-inferred techniques ---
+    term_counts, total_windows = _build_document_term_counts(source_text)
+
+    for t in techniques:
+        if t.get("source") != "ontology-inference":
+            continue
+
+        pmi = pmi_score_technique(t, source_text, term_counts, total_windows)
+        t["x_pmi_score"] = round(pmi, 3)
+
+        # PMI scoring only downgrades broad-profile entity techniques
+        # (already flagged by clique filter). Others keep their confidence.
+        is_broad = t.get("x_broad_profile_entity")
+
+        if is_broad:
+            if pmi <= 0:
+                t["confidence"] = min(t.get("confidence", 1.0), 0.40)
+            elif pmi < 1.5:
+                t["confidence"] = min(t.get("confidence", 1.0), 0.50)
+            elif pmi >= 2.5:
+                t["confidence"] = min(t.get("confidence", 1.0) + 0.05, 0.97)
+
+    # --- 4. Cap broad-profile entities to top-N by PMI ---
+    MAX_PER_BROAD_ENTITY = 15
+    broad_entities = defaultdict(list)
+    non_broad = []
+
+    for t in techniques:
+        entity = t.get("x_broad_profile_entity")
+        if entity and t.get("source") == "ontology-inference":
+            broad_entities[entity].append(t)
+        else:
+            non_broad.append(t)
+
+    for entity, techs in broad_entities.items():
+        # Sort by PMI score descending, keep top N
+        techs.sort(key=lambda x: x.get("x_pmi_score", 0), reverse=True)
+        for t in techs[:MAX_PER_BROAD_ENTITY]:
+            non_broad.append(t)
+        dropped_count = max(0, len(techs) - MAX_PER_BROAD_ENTITY)
+        if dropped_count:
+            print(f"[PRECISION] Capped {entity}: kept {min(len(techs), MAX_PER_BROAD_ENTITY)}, dropped {dropped_count}")
+
+    techniques = non_broad
+
+    # --- 5. Confidence threshold ---
+    kept = []
+    dropped = 0
+    for t in techniques:
+        if t.get("confidence", 1.0) >= min_confidence:
+            kept.append(t)
+        else:
+            dropped += 1
+
+    # Stats
+    ontology_kept = sum(1 for t in kept if t.get("source") == "ontology-inference")
+    ontology_dropped = sum(1 for t in techniques if t.get("source") == "ontology-inference") - ontology_kept
+    broad_flagged = sum(1 for t in kept if t.get("x_broad_profile_entity"))
+    orphan_flagged = sum(1 for t in kept if t.get("x_hierarchy_orphan"))
+
+    print(f"[PRECISION] Output: {len(kept)} kept, {dropped} dropped")
+    print(f"[PRECISION] Ontology: {ontology_kept} kept, {ontology_dropped} dropped")
+    if broad_flagged:
+        print(f"[PRECISION] Broad-profile downgraded: {broad_flagged}")
+    if orphan_flagged:
+        print(f"[PRECISION] Hierarchy orphans: {orphan_flagged}")
+
+    return kept

--- a/app/utilities/cti_relation_extractor.py
+++ b/app/utilities/cti_relation_extractor.py
@@ -260,13 +260,17 @@ def extract_triples(text: str, known_entities: set[str],
                         subject_tok = child
                     if child.dep_ in ("dobj", "attr"):
                         object_toks.append(child)
+                        # Walk into dobj's prepositional children
+                        # "deployed mechanisms including AnyDesk and TeamViewer"
+                        for dobj_child in child.subtree:
+                            if dobj_child.dep_ == "pobj" and dobj_child != child:
+                                object_toks.append(dobj_child)
                     # Prepositional objects for verbs like "connect to X"
                     if child.dep_ == "prep":
                         for pobj in child.children:
                             if pobj.dep_ == "pobj":
                                 object_toks.append(pobj)
                     # Complement clauses: "leverage X to recover Y"
-                    # The dobj of the complement is also relevant
                     if child.dep_ in ("ccomp", "xcomp"):
                         for grandchild in child.children:
                             if grandchild.dep_ in ("nsubj", "dobj"):

--- a/app/utilities/cti_relation_extractor.py
+++ b/app/utilities/cti_relation_extractor.py
@@ -1,0 +1,360 @@
+"""
+cti_relation_extractor.py — Improved Relationship Extraction
+
+Extracts (subject, verb, object) triples from CTI text using spaCy
+dependency parsing with three critical improvements over the original:
+
+1. Compound subject resolution: "BlackCat operators" → BlackCat
+2. Conjunction splitting: "deployed A, B and C" → 3 relationships
+3. Passive voice inversion: "Mimikatz was deployed by X" → X deploys Mimikatz
+
+Then validates each triple against the entity ontology to keep only
+grounded relationships.
+
+No ML. No LLM. Pure dependency parse + ontology lookup.
+"""
+
+import re
+from plugins.mcp.app.utilities.nlp_model import nlp
+
+
+# ============================================================
+# VALID CTI RELATIONSHIP VERBS
+# ============================================================
+
+CTI_VERBS = {
+    "use", "employ", "deploy", "execute", "exploit", "target",
+    "leverage", "utilize", "compromise", "attack", "infect",
+    "download", "upload", "exfiltrate", "steal", "harvest",
+    "encrypt", "decrypt", "disable", "modify", "delete",
+    "create", "install", "inject", "drop", "deliver",
+    "propagate", "spread", "scan", "enumerate", "discover",
+    "dump", "extract", "collect", "access", "connect",
+    "communicate", "transfer", "move", "copy", "archive",
+    "compress", "terminate", "stop", "kill", "clear",
+    "gain", "establish", "maintain", "achieve", "perform",
+    "conduct", "launch", "initiate",
+}
+
+# Verbs that indicate analyst narration, not adversary action
+REPORTER_VERBS = {
+    "report", "describe", "note", "observe", "identify",
+    "analyze", "assess", "document", "publish", "state",
+    "indicate", "suggest", "reveal", "show", "find",
+    "discover", "track", "monitor", "detect", "warn",
+    "believe", "confirm", "attribute",
+}
+
+
+# ============================================================
+# SUBJECT RESOLUTION
+# ============================================================
+
+def _resolve_full_subject(tok):
+    """
+    Resolve compound noun phrases to get the full subject.
+    "BlackCat operators" → "BlackCat operators"
+    "APT29 group" → "APT29 group"
+    "the malware" → "the malware"
+    """
+    # Collect compound modifiers and the head
+    compounds = []
+    for child in tok.children:
+        if child.dep_ in ("compound", "amod", "flat", "appos") and child.i < tok.i:
+            # Recursively get compounds of compounds
+            for subchild in child.children:
+                if subchild.dep_ == "compound" and subchild.i < child.i:
+                    compounds.append(subchild)
+            compounds.append(child)
+
+    if compounds:
+        all_tokens = sorted(compounds + [tok], key=lambda t: t.i)
+        return " ".join(t.text for t in all_tokens)
+
+    return tok.text
+
+
+def _resolve_subject_entity(tok, known_entities):
+    """
+    Given a subject token, find the best matching known entity.
+
+    Strategy:
+    1. Check full compound noun phrase against known entities
+    2. Check individual compound parts (and their subtrees)
+    3. Check the token itself
+    4. Walk UP the tree — if subject's head has a known entity nearby
+    """
+    full = _resolve_full_subject(tok).lower()
+
+    # Check full phrase
+    for ent in known_entities:
+        if ent in full or full in ent:
+            return ent
+
+    # Check compound parts and their subtrees
+    for child in tok.children:
+        if child.dep_ in ("compound", "flat", "amod", "nmod", "poss"):
+            c_lower = child.text.lower()
+            for ent in known_entities:
+                if ent in c_lower or c_lower in ent:
+                    return ent
+            # Check subtree of compound
+            subtree_text = " ".join(t.text.lower() for t in child.subtree)
+            for ent in known_entities:
+                if ent in subtree_text:
+                    return ent
+
+    # Check token itself
+    tok_lower = tok.text.lower()
+    for ent in known_entities:
+        if ent in tok_lower or tok_lower in ent:
+            return ent
+
+    return None
+
+
+# ============================================================
+# OBJECT RESOLUTION (with conjunction splitting)
+# ============================================================
+
+def _resolve_objects(tok, known_entities):
+    """
+    Resolve direct objects including conjunctions.
+    "deployed A, B and C" → [A, B, C]
+
+    Returns list of (object_text, matched_entity_or_None)
+    """
+    objects = []
+
+    # Get the primary object and its conjuncts
+    all_objects = [tok] + list(tok.conjuncts)
+
+    for obj_tok in all_objects:
+        # Get full noun phrase for this object
+        subtree_text = " ".join(t.text for t in obj_tok.subtree
+                                if t.dep_ != "cc" and t.text.lower() not in ("and", "or", ","))
+        obj_text = subtree_text.strip()
+
+        # Try to match against known entities
+        obj_lower = obj_text.lower()
+        matched = None
+        for ent in known_entities:
+            if ent in obj_lower or obj_lower in ent:
+                matched = ent
+                break
+
+        # If no match on full phrase, try just the head token
+        if not matched:
+            head_lower = obj_tok.text.lower()
+            for ent in known_entities:
+                if ent in head_lower or head_lower in ent:
+                    matched = ent
+                    break
+
+        objects.append((obj_text, matched))
+
+    return objects
+
+
+# ============================================================
+# CORE TRIPLE EXTRACTION
+# ============================================================
+
+def extract_triples(text: str, known_entities: set[str]) -> list[dict]:
+    """
+    Extract (subject, verb, object) triples from CTI text.
+
+    Handles:
+    - Active voice: "BlackCat uses Mimikatz"
+    - Passive voice: "Mimikatz was deployed by BlackCat"
+    - Compound subjects: "BlackCat operators leverage tools"
+    - Conjunctions: "deployed A, B and C"
+    - Ontology grounding: only emits if subject OR object is known entity
+
+    Returns list of relationship dicts with provenance.
+    """
+    known_lower = {e.lower() for e in known_entities if e}
+    doc = nlp(text[:nlp.max_length])
+    triples = []
+
+    for sent in doc.sents:
+        sent_text = sent.text.strip()
+        if len(sent_text) < 10:
+            continue
+
+        for tok in sent:
+            # Only consider real verbs
+            if tok.pos_ != "VERB":
+                continue
+            if tok.tag_ in ("MD",):  # skip modals
+                continue
+
+            verb_lemma = tok.lemma_.lower()
+
+            # Skip reporter verbs
+            if verb_lemma in REPORTER_VERBS:
+                continue
+
+            # Must be a CTI-relevant verb
+            if verb_lemma not in CTI_VERBS:
+                continue
+
+            # ── PASSIVE VOICE ──
+            is_passive = any(c.dep_ == "auxpass" for c in tok.children)
+
+            if is_passive:
+                # Passive: "X was VERBed by Y"
+                # nsubjpass = the object (what was acted on)
+                # agent/pobj = the real subject (who did it)
+                passive_obj = None
+                agent = None
+
+                for child in tok.children:
+                    if child.dep_ == "nsubjpass":
+                        passive_obj = child
+                    if child.dep_ == "agent":
+                        for pobj_child in child.children:
+                            if pobj_child.dep_ == "pobj":
+                                agent = pobj_child
+
+                if passive_obj and agent:
+                    subj_entity = _resolve_subject_entity(agent, known_lower)
+                    obj_text = _resolve_full_subject(passive_obj)
+                    obj_entity = None
+                    for ent in known_lower:
+                        if ent in obj_text.lower():
+                            obj_entity = ent
+                            break
+
+                    # Must have at least one grounded entity
+                    if subj_entity or obj_entity:
+                        triples.append({
+                            "source": subj_entity or _resolve_full_subject(agent),
+                            "relationship": verb_lemma,
+                            "target": obj_entity or obj_text,
+                            "evidence": sent_text,
+                            "voice": "passive",
+                            "source_grounded": subj_entity is not None,
+                            "target_grounded": obj_entity is not None,
+                        })
+
+            else:
+                # ── ACTIVE VOICE ──
+                subject_tok = None
+                object_toks = []
+
+                for child in tok.children:
+                    if child.dep_ in ("nsubj",):
+                        subject_tok = child
+                    if child.dep_ in ("dobj", "attr"):
+                        object_toks.append(child)
+                    # Prepositional objects for verbs like "connect to X"
+                    if child.dep_ == "prep":
+                        for pobj in child.children:
+                            if pobj.dep_ == "pobj":
+                                object_toks.append(pobj)
+                    # Complement clauses: "leverage X to recover Y"
+                    # The dobj of the complement is also relevant
+                    if child.dep_ in ("ccomp", "xcomp"):
+                        for grandchild in child.children:
+                            if grandchild.dep_ in ("nsubj", "dobj"):
+                                object_toks.append(grandchild)
+
+                # If no direct subject, check if verb is an acl modifier
+                # "The group [deployed X]" — group is ROOT, deployed is acl
+                if not subject_tok and tok.dep_ in ("acl", "relcl", "advcl"):
+                    head = tok.head
+                    if head.pos_ in ("NOUN", "PROPN"):
+                        subject_tok = head
+
+                if not subject_tok or not object_toks:
+                    continue
+
+                # Resolve subject
+                subj_entity = _resolve_subject_entity(subject_tok, known_lower)
+
+                # Resolve each object (with conjunction splitting)
+                for obj_tok in object_toks:
+                    resolved_objects = _resolve_objects(obj_tok, known_lower)
+
+                    for obj_text, obj_entity in resolved_objects:
+                        if not obj_text or len(obj_text) < 2:
+                            continue
+
+                        # Must have at least one grounded entity
+                        if subj_entity or obj_entity:
+                            triples.append({
+                                "source": subj_entity or _resolve_full_subject(subject_tok),
+                                "relationship": verb_lemma,
+                                "target": obj_entity or obj_text,
+                                "evidence": sent_text,
+                                "voice": "active",
+                                "source_grounded": subj_entity is not None,
+                                "target_grounded": obj_entity is not None,
+                            })
+
+    return triples
+
+
+# ============================================================
+# ONTOLOGY-GROUNDED FILTERING
+# ============================================================
+
+def filter_grounded_relationships(
+    triples: list[dict],
+    require_both: bool = False,
+) -> list[dict]:
+    """
+    Filter relationships to only those grounded in known entities.
+
+    require_both=False: at least one side must be a known entity (default)
+    require_both=True: both sides must be known entities (strict)
+    """
+    kept = []
+    for t in triples:
+        src_grounded = t.get("source_grounded", False)
+        tgt_grounded = t.get("target_grounded", False)
+
+        if require_both and not (src_grounded and tgt_grounded):
+            continue
+        if not require_both and not (src_grounded or tgt_grounded):
+            continue
+
+        # Remove self-references
+        if t["source"].lower() == t["target"].lower():
+            continue
+
+        kept.append(t)
+
+    return kept
+
+
+# ============================================================
+# DEDUP + CONFIDENCE
+# ============================================================
+
+def dedup_triples(triples: list[dict]) -> list[dict]:
+    """
+    Deduplicate by (source, relationship, target).
+    Multiple evidence sentences boost confidence.
+    """
+    seen = {}
+    for t in triples:
+        key = (t["source"].lower(), t["relationship"], t["target"].lower())
+        if key not in seen:
+            seen[key] = {
+                "source": t["source"],
+                "relationship": t["relationship"],
+                "target": t["target"],
+                "confidence": 0.70,
+                "evidence": [t["evidence"]],
+                "source_context": "sentence",
+                "source_grounded": t.get("source_grounded", False),
+                "target_grounded": t.get("target_grounded", False),
+            }
+        else:
+            if t["evidence"] not in seen[key]["evidence"]:
+                seen[key]["evidence"].append(t["evidence"])
+                seen[key]["confidence"] = min(seen[key]["confidence"] + 0.08, 0.95)
+
+    return list(seen.values())

--- a/app/utilities/cti_relation_extractor.py
+++ b/app/utilities/cti_relation_extractor.py
@@ -160,7 +160,8 @@ def _resolve_objects(tok, known_entities):
 # CORE TRIPLE EXTRACTION
 # ============================================================
 
-def extract_triples(text: str, known_entities: set[str]) -> list[dict]:
+def extract_triples(text: str, known_entities: set[str],
+                    default_actor: str = None) -> list[dict]:
     """
     Extract (subject, verb, object) triples from CTI text.
 
@@ -169,11 +170,22 @@ def extract_triples(text: str, known_entities: set[str]) -> list[dict]:
     - Passive voice: "Mimikatz was deployed by BlackCat"
     - Compound subjects: "BlackCat operators leverage tools"
     - Conjunctions: "deployed A, B and C"
+    - Generic subjects: "the group", "threat actors", "attackers"
+      → resolved to default_actor if provided
     - Ontology grounding: only emits if subject OR object is known entity
 
     Returns list of relationship dicts with provenance.
     """
     known_lower = {e.lower() for e in known_entities if e}
+
+    # Generic subject terms that should resolve to the default actor
+    GENERIC_SUBJECTS = {
+        "group", "actors", "attackers", "operator", "operators",
+        "threat", "adversary", "adversaries", "intruders",
+        "hackers", "gang", "affiliate", "affiliates", "they",
+        "it", "malware", "ransomware", "campaign",
+    }
+
     doc = nlp(text[:nlp.max_length])
     triples = []
 
@@ -272,6 +284,14 @@ def extract_triples(text: str, known_entities: set[str]) -> list[dict]:
 
                 # Resolve subject
                 subj_entity = _resolve_subject_entity(subject_tok, known_lower)
+
+                # If subject is generic ("the group", "attackers", etc.)
+                # resolve to the default actor
+                if not subj_entity and default_actor:
+                    subj_text = _resolve_full_subject(subject_tok).lower()
+                    subj_words = set(subj_text.split())
+                    if subj_words & GENERIC_SUBJECTS:
+                        subj_entity = default_actor
 
                 # Resolve each object (with conjunction splitting)
                 for obj_tok in object_toks:

--- a/app/utilities/cti_relationships.py
+++ b/app/utilities/cti_relationships.py
@@ -443,11 +443,6 @@ def _extract_relationships_from_doc(doc, ir, source_label):
                 if source_label in ("behavior", "behavior_dependency_recovery"):
                     threshold = 0.45
 
-                status = None
-                if conf < threshold:
-                    status = "abstract-nominal"
-                    candidate["x_cti_resolution_status"] = "pending"
-                    
                 candidate = {
                     "source": src,
                     "relationship": rel_class,
@@ -457,8 +452,9 @@ def _extract_relationships_from_doc(doc, ir, source_label):
                     "source_context": source_label,
                 }
 
-                if status:
-                    candidate["status"] = status
+                if conf < threshold:
+                    candidate["status"] = "abstract-nominal"
+                    candidate["x_cti_resolution_status"] = "pending"
 
                 if not is_actionable_relationship(candidate):
                     REL_REJECTIONS.append({

--- a/app/utilities/cti_relationships.py
+++ b/app/utilities/cti_relationships.py
@@ -11,18 +11,13 @@ Key guarantees:
 - Backward compatible with cti_pipeline_stage1.py
 """
 
-import spacy, re
+import re
 from functools import lru_cache
 from nltk.corpus import wordnet as wn
 
+from plugins.mcp.app.utilities.nlp_model import nlp
 from plugins.mcp.app.utilities.cti_mitre_extract import cosine_sim
 from plugins.mcp.app.utilities.cti_linguistics import normalize_behavior_text, canonicalize_relationship_endpoints
-
-# ============================================================
-# NLP MODEL (GLOBAL, SINGLE LOAD)
-# ============================================================
-
-nlp = spacy.load("en_core_web_lg")
 
 # ============================================================
 # VECTOR CACHE (PERFORMANCE CRITICAL)

--- a/app/utilities/cti_stix_builders.py
+++ b/app/utilities/cti_stix_builders.py
@@ -59,6 +59,7 @@ def make_malware(m: dict) -> dict:
 
     obj = {
         "type": "malware",
+        "spec_version": "2.1",
         "id": new_stix_id("malware"),
         "created": now(),
         "modified": now(),
@@ -89,6 +90,7 @@ def make_tool(t: dict) -> dict:
 
     obj = {
         "type": "tool",
+        "spec_version": "2.1",
         "id": new_stix_id("tool"),
         "created": now(),
         "modified": now(),
@@ -116,11 +118,11 @@ def make_threat_actor(ta: dict) -> dict:
 
     obj = {
         "type": "threat-actor",
+        "spec_version": "2.1",
         "id": new_stix_id("threat-actor"),
         "created": now(),
         "modified": now(),
         "name": name,
-        "roles": ["threat-actor"],
     }
 
     if "description" in ta:
@@ -144,6 +146,7 @@ def make_infrastructure(i: dict) -> dict:
 
     obj = {
         "type": "infrastructure",
+        "spec_version": "2.1",
         "id": new_stix_id("infrastructure"),
         "created": now(),
         "modified": now(),
@@ -212,7 +215,10 @@ def make_attack_pattern(ttp_text, taxonomy: dict):
 
         ap = {
             "type": "attack-pattern",
+            "spec_version": "2.1",
             "id": obj["id"],
+            "created": obj.get("created", now()),
+            "modified": obj.get("modified", now()),
             "name": obj.get("name"),
             "description": obj.get("description", ""),
             "external_references": obj.get("external_references", []),
@@ -235,7 +241,10 @@ def make_attack_pattern(ttp_text, taxonomy: dict):
         if stype == "attack-pattern":
             ap = {
                 "type": "attack-pattern",
+                "spec_version": "2.1",
                 "id": sid,
+                "created": sobj.get("created", now()),
+                "modified": sobj.get("modified", now()),
                 "name": sobj.get("name"),
                 "description": sobj.get("description", ""),
                 "external_references": sobj.get("external_references", []),
@@ -253,6 +262,7 @@ def make_attack_pattern(ttp_text, taxonomy: dict):
     # ----------------------------
     ap = {
         "type": "attack-pattern",
+        "spec_version": "2.1",
         "id": new_stix_id("attack-pattern"),
         "created": now(),
         "modified": now(),
@@ -282,6 +292,7 @@ def make_observed_data(behavior: str) -> dict:
 
     obj = {
         "type": "observed-data",
+        "spec_version": "2.1",
         "id": new_stix_id("observed-data"),
         "created": now(),
         "modified": now(),
@@ -312,6 +323,7 @@ def make_relationship(rel_type: str, src_id: str, dst_id: str) -> dict:
 
     obj = {
         "type": "relationship",
+        "spec_version": "2.1",
         "id": new_stix_id("relationship"),
         "created": now(),
         "modified": now(),

--- a/app/utilities/cti_stix_merge.py
+++ b/app/utilities/cti_stix_merge.py
@@ -1,0 +1,221 @@
+"""
+cti_stix_merge.py — Multi-Source STIX Bundle Merge Pipeline
+
+Merges multiple single-source STIX bundles into one unified bundle.
+Handles conflicts using confidence scoring, provenance tracking,
+and majority voting — inspired by how GTI merges multi-source CTI.
+
+No LLM required. Fully deterministic.
+
+Conflict resolution strategy:
+1. Entities: deduplicate by canonical name, merge descriptions,
+   track source provenance, use highest confidence
+2. Techniques: deduplicate by ATT&CK ID, merge evidence from
+   all sources, boost confidence when multiple sources agree
+3. Relationships: deduplicate by (source, verb, target) triple,
+   merge evidence, boost when corroborated across sources
+4. Conflicts: when sources disagree on entity type, use MITRE
+   taxonomy as authority; when both valid, keep both with provenance
+"""
+
+import json
+import re
+from collections import defaultdict
+from datetime import datetime
+
+
+def merge_stix_bundles(bundles: list[dict], source_names: list[str] = None) -> dict:
+    """
+    Merge multiple STIX bundles into one unified bundle.
+
+    Args:
+        bundles: list of STIX bundle dicts (each from a single source)
+        source_names: optional list of source names (parallel to bundles)
+
+    Returns:
+        Merged STIX bundle with provenance tracking and confidence scoring
+    """
+    if not bundles:
+        return _empty_bundle()
+
+    if source_names is None:
+        source_names = [f"source-{i}" for i in range(len(bundles))]
+
+    # Collect all objects by type
+    entities = defaultdict(list)     # canonical_name → [(obj, source_name)]
+    techniques = defaultdict(list)   # technique_id → [(obj, source_name)]
+    relationships = defaultdict(list) # (src_name, verb, tgt_name) → [(obj, source)]
+    other_objects = []               # observed-data, etc.
+
+    for bundle, src_name in zip(bundles, source_names):
+        for obj in bundle.get("objects", []):
+            otype = obj.get("type", "")
+
+            if otype in ("malware", "tool", "threat-actor", "infrastructure"):
+                name = (obj.get("name") or "").lower().strip()
+                if name:
+                    entities[name].append((obj, src_name))
+
+            elif otype == "attack-pattern":
+                tid = None
+                for ref in obj.get("external_references", []):
+                    eid = ref.get("external_id", "")
+                    if eid.startswith("T"):
+                        tid = eid
+                        break
+                if tid:
+                    techniques[tid].append((obj, src_name))
+                else:
+                    # No T-number — use name as key
+                    name = (obj.get("name") or "").lower().strip()
+                    if name:
+                        techniques[f"name:{name}"].append((obj, src_name))
+
+            elif otype == "relationship":
+                src_ref = (obj.get("source_ref") or "")
+                tgt_ref = (obj.get("target_ref") or "")
+                rel_type = (obj.get("relationship_type") or "").lower()
+                key = (src_ref, rel_type, tgt_ref)
+                relationships[key].append((obj, src_name))
+
+            else:
+                other_objects.append(obj)
+
+    # ========================================================
+    # MERGE ENTITIES
+    # ========================================================
+    merged_objects = []
+    name_to_id = {}  # for relationship resolution
+
+    for name, entries in entities.items():
+        # Use the type from the first occurrence, but check for conflicts
+        types = {e[0].get("type") for e in entries}
+        sources = {e[1] for e in entries}
+
+        # Pick the "best" object (highest confidence, most complete)
+        best = max(entries, key=lambda e: (
+            e[0].get("confidence", 50),
+            len(e[0].get("description", "")),
+        ))
+
+        merged_obj = dict(best[0])
+
+        # Add provenance
+        merged_obj["x_cti_sources"] = sorted(sources)
+        merged_obj["x_cti_source_count"] = len(sources)
+
+        # Boost confidence based on source agreement
+        base_conf = merged_obj.get("confidence", 50)
+        if isinstance(base_conf, (int, float)):
+            # Each additional source adds confidence
+            boost = min((len(sources) - 1) * 10, 30)
+            merged_obj["confidence"] = min(base_conf + boost, 100)
+
+        # Merge descriptions from all sources
+        descriptions = set()
+        for obj, _ in entries:
+            desc = (obj.get("description") or "").strip()
+            if desc:
+                descriptions.add(desc)
+        if descriptions:
+            merged_obj["description"] = " | ".join(sorted(descriptions))
+
+        # Handle type conflicts
+        if len(types) > 1:
+            merged_obj["x_cti_type_conflict"] = sorted(types)
+            # Use most common type
+            type_counts = defaultdict(int)
+            for obj, _ in entries:
+                type_counts[obj.get("type")] += 1
+            merged_obj["type"] = max(type_counts, key=type_counts.get)
+
+        merged_objects.append(merged_obj)
+        name_to_id[name] = merged_obj.get("id")
+
+    entity_count = len(merged_objects)
+
+    # ========================================================
+    # MERGE TECHNIQUES
+    # ========================================================
+    for tid, entries in techniques.items():
+        sources = {e[1] for e in entries}
+        best = entries[0][0]  # First occurrence
+
+        merged_tech = dict(best)
+        merged_tech["x_cti_sources"] = sorted(sources)
+        merged_tech["x_cti_source_count"] = len(sources)
+
+        # Confidence boost from multi-source corroboration
+        base_conf = merged_tech.get("confidence", 50)
+        if isinstance(base_conf, (int, float)):
+            boost = min((len(sources) - 1) * 15, 40)
+            merged_tech["confidence"] = min(base_conf + boost, 100)
+
+        # Merge evidence
+        all_evidence = set()
+        for obj, src in entries:
+            for ev in (obj.get("x_cti_evidence") or []):
+                all_evidence.add(str(ev))
+            # Also track which source contributed
+            all_evidence.add(f"[source: {src}]")
+        if all_evidence:
+            merged_tech["x_cti_evidence"] = sorted(all_evidence)
+
+        merged_objects.append(merged_tech)
+
+    technique_count = len(merged_objects) - entity_count
+
+    # ========================================================
+    # MERGE RELATIONSHIPS
+    # ========================================================
+    for key, entries in relationships.items():
+        sources = {e[1] for e in entries}
+        best = entries[0][0]
+
+        merged_rel = dict(best)
+        merged_rel["x_cti_sources"] = sorted(sources)
+
+        # Confidence boost from corroboration
+        base_conf = merged_rel.get("x_cti_confidence")
+        if isinstance(base_conf, (int, float)):
+            boost = min((len(sources) - 1) * 15, 40)
+            merged_rel["x_cti_confidence"] = min(base_conf + boost, 95)
+
+        merged_objects.append(merged_rel)
+
+    rel_count = len(merged_objects) - entity_count - technique_count
+
+    # Add other objects (observed-data, etc.)
+    merged_objects.extend(other_objects)
+
+    # ========================================================
+    # BUILD FINAL BUNDLE
+    # ========================================================
+    bundle = {
+        "type": "bundle",
+        "id": f"bundle--merged-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}",
+        "spec_version": "2.1",
+        "objects": merged_objects,
+        "x_cti_merge_metadata": {
+            "source_count": len(bundles),
+            "source_names": source_names,
+            "merged_at": datetime.utcnow().isoformat() + "Z",
+            "entities_merged": entity_count,
+            "techniques_merged": technique_count,
+            "relationships_merged": rel_count,
+        },
+    }
+
+    print(f"[MERGE] {len(bundles)} sources → {len(merged_objects)} objects "
+          f"({entity_count} entities, {technique_count} techniques, {rel_count} relationships)")
+
+    return bundle
+
+
+def _empty_bundle():
+    return {
+        "type": "bundle",
+        "id": "bundle--empty",
+        "spec_version": "2.1",
+        "objects": [],
+    }

--- a/app/utilities/cti_taxonomy_loader.py
+++ b/app/utilities/cti_taxonomy_loader.py
@@ -21,8 +21,8 @@ This replaces the old loader that assumed 3 separate JSON files.
 
 import json, re
 from pathlib import Path
-import spacy
-nlp = spacy.load("en_core_web_lg")
+
+from plugins.mcp.app.utilities.nlp_model import nlp
 
 # ======================================================================
 #  Load the unified MITRE ATT&CK bundle

--- a/app/utilities/cti_taxonomy_loader.py
+++ b/app/utilities/cti_taxonomy_loader.py
@@ -21,6 +21,7 @@ This replaces the old loader that assumed 3 separate JSON files.
 
 import json, re
 from pathlib import Path
+from functools import lru_cache
 
 from plugins.mcp.app.utilities.nlp_model import nlp
 
@@ -51,6 +52,8 @@ def load_mitre_bundle():
 #  Parse and index MITRE objects
 # ======================================================================
 
+_taxonomy_cache = {}
+
 def load_mitre_taxonomy(taxonomy=None):
     """
     Extracts all relevant MITRE STIX objects and builds fast lookup tables.
@@ -64,6 +67,9 @@ def load_mitre_taxonomy(taxonomy=None):
         name_index
         attack_id_index
     """
+
+    if _taxonomy_cache:
+        return _taxonomy_cache
 
     try:
         bundle = load_mitre_bundle()
@@ -180,7 +186,7 @@ def load_mitre_taxonomy(taxonomy=None):
     print("[DEBUG][MITRE] name_index entries:", len(name_index))
     print("[DEBUG][MITRE] attack_id_index entries:", len(attack_id_index))
       
-    return {
+    result = {
         "attack_patterns": attack_patterns,
         "malware": malware,
         "groups": groups,
@@ -190,6 +196,8 @@ def load_mitre_taxonomy(taxonomy=None):
         "name_index": name_index,
         "attack_id_index": attack_id_index,
     }
+    _taxonomy_cache.update(result)
+    return result
 
 
 # ======================================================================
@@ -220,6 +228,7 @@ def lookup_attack_id(tid: str, taxonomy: dict):
     return taxonomy["attack_id_index"].get(tid.upper().strip())
 
 
+@lru_cache(maxsize=1)
 def build_normalized_attack_patterns():
     """
     Unified MITRE technique index for Stage-1 and Stage-2.

--- a/app/utilities/llm_client.py
+++ b/app/utilities/llm_client.py
@@ -213,7 +213,8 @@ class LLMClient:
     # --------------------------------------------------
 
     async def _ollama_generate(self, prompt, model, api_base, temperature):
-        async with aiohttp.ClientSession() as session:
+        timeout = aiohttp.ClientTimeout(total=600)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.post(
                 f"{api_base}/api/generate",
                 json={

--- a/app/utilities/nlp/cti_behavior_expansion.py
+++ b/app/utilities/nlp/cti_behavior_expansion.py
@@ -8,10 +8,9 @@ Purpose:
 - Emit low-confidence behavior candidates only
 """
 
-import spacy
 from nltk.corpus import wordnet as wn
 
-nlp = spacy.load("en_core_web_lg")
+from plugins.mcp.app.utilities.nlp_model import nlp
 
 
 def recover_nominalized_behaviors(text: str) -> list[dict]:

--- a/app/utilities/nlp/cti_nlp_enhancements.py
+++ b/app/utilities/nlp/cti_nlp_enhancements.py
@@ -24,8 +24,8 @@ def _log(msg: str):
     print(f"[DEPNLP] {msg}")
 
 def normalize_phrase(s: str) -> str:
-    """Normalize strings into canonical alphanumeric form."""
-    return re.sub(r"[^a-z0-9]+", "", s.lower())
+    """Normalize strings into canonical alphanumeric form, preserving dots for IPs/domains."""
+    return re.sub(r"[^a-z0-9.]+", "", s.lower())
 
 # ---------------------------------------------------------------------------
 # Behavior extraction helper
@@ -161,29 +161,34 @@ def clean_ir_nlp_layer1(ir: dict, original_text: str) -> dict:
     for a in actors:
         if isinstance(a, dict):
             name = a.get("name", "")
-            if not name:
-                continue
-            if not is_valid_actor(name):
-                removed.append(name)
-                continue
-
-            a["name"] = normalize_actor_name(name)
-            cleaned.append(a)
-
         elif isinstance(a, str):
             name = a.strip()
-            if not name:
-                continue
-            if not is_valid_actor(name):
-                removed.append(name)
-                continue
+            a = {"name": name, "description": "", "confidence": 0.5, "source": "recovered-string"}
+        else:
+            continue
 
-            cleaned.append({
-                "name": normalize_actor_name(name),
-                "description": "",
-                "confidence": 0.5,
-                "source": "recovered-string"
-            })
+        if not name:
+            continue
+
+        # Split slash-separated actor names into individual actors with aliases
+        if "/" in name:
+            parts = [p.strip() for p in name.split("/") if p.strip()]
+            for part in parts:
+                if is_valid_actor(part):
+                    cleaned.append({
+                        "name": normalize_actor_name(part),
+                        "description": a.get("description", ""),
+                        "aliases": [p for p in parts if p != part],
+                        "confidence": a.get("confidence", 0.5),
+                    })
+            continue
+
+        if not is_valid_actor(name):
+            removed.append(name)
+            continue
+
+        a["name"] = normalize_actor_name(name)
+        cleaned.append(a)
 
     ir["threat_actors"] = cleaned
     _log(f"Actors removed: {removed}")

--- a/app/utilities/nlp/cti_nlp_enhancements.py
+++ b/app/utilities/nlp/cti_nlp_enhancements.py
@@ -13,11 +13,10 @@ Output conforms to:
     ir["threat_actors"] cleaned + normalized
 """
 
-import spacy
 import re
 from rapidfuzz import fuzz
 
-nlp = spacy.load("en_core_web_lg")
+from plugins.mcp.app.utilities.nlp_model import nlp
 
 def _log(msg: str):
     """Simple stdout logger for tee-based debugging."""

--- a/app/utilities/nlp_model.py
+++ b/app/utilities/nlp_model.py
@@ -1,0 +1,19 @@
+"""
+nlp_model.py — Shared spaCy model singleton
+
+All modules import from here instead of calling spacy.load() directly.
+This ensures the 560MB en_core_web_lg model is loaded exactly once.
+"""
+
+import spacy
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
+def get_nlp():
+    """Load en_core_web_lg exactly once, cached for process lifetime."""
+    return spacy.load("en_core_web_lg")
+
+
+# Module-level alias for backward compatibility
+nlp = get_nlp()

--- a/tests/test_relation_extractor.py
+++ b/tests/test_relation_extractor.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+Unit tests for cti_relation_extractor.py
+
+Tests relationship extraction across diverse CTI writing styles,
+threat actors, and sentence structures. Not tuned to any specific
+adversary — tests must pass for ANY CTI data.
+
+Run: python3 -m pytest tests/test_relation_extractor.py -v
+  or: python3 tests/test_relation_extractor.py
+"""
+
+import sys
+from pathlib import Path
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1].parents[1]))
+
+from plugins.mcp.app.utilities.cti_relation_extractor import (
+    extract_triples,
+    filter_grounded_relationships,
+    dedup_triples,
+)
+
+# ============================================================
+# TEST SENTENCES — diverse actors, styles, structures
+# ============================================================
+
+TEST_CASES = [
+    # ── ACTIVE VOICE, SIMPLE ──
+    {
+        "name": "active_simple_apt29",
+        "text": "APT29 uses Cobalt Strike for command and control.",
+        "entities": {"apt29", "cobalt strike"},
+        "expect_min": 1,
+        "expect_contains": [("apt29", "use", "cobalt strike")],
+    },
+    {
+        "name": "active_simple_lazarus",
+        "text": "Lazarus Group deployed ELECTRICFISH to establish encrypted tunnels.",
+        "entities": {"lazarus group", "electricfish"},
+        "expect_min": 1,
+        "expect_contains": [("lazarus group", "deploy", "electricfish")],
+    },
+
+    # ── COMPOUND SUBJECT ──
+    {
+        "name": "compound_subject_blackcat",
+        "text": "BlackCat operators leverage Mimikatz to recover stored passwords.",
+        "entities": {"blackcat", "mimikatz"},
+        "expect_min": 1,
+        "expect_source": "blackcat",
+    },
+    {
+        "name": "compound_subject_apt28",
+        "text": "APT28 actors deployed X-Agent across compromised hosts.",
+        "entities": {"apt28", "x-agent"},
+        "expect_min": 1,
+        "expect_source": "apt28",
+    },
+    {
+        "name": "compound_subject_fin7",
+        "text": "FIN7 members utilized Carbanak malware to access banking systems.",
+        "entities": {"fin7", "carbanak"},
+        "expect_min": 1,
+        "expect_source": "fin7",
+    },
+
+    # ── CONJUNCTION SPLITTING ──
+    {
+        "name": "conjunction_three_tools",
+        "text": "The group deployed AnyDesk, TeamViewer and Cobalt Strike for remote access.",
+        "entities": {"anydesk", "teamviewer", "cobalt strike"},
+        "expect_min": 2,  # Should get at least 2 of the 3
+    },
+    {
+        "name": "conjunction_two_malware",
+        "text": "Sandworm deployed NotPetya and Industroyer against Ukrainian infrastructure.",
+        "entities": {"sandworm", "notpetya", "industroyer"},
+        "expect_min": 2,
+        "expect_source": "sandworm",
+    },
+    {
+        "name": "conjunction_exfil_tools",
+        "text": "The attackers used rclone and MEGAsync to exfiltrate sensitive data.",
+        "entities": {"rclone", "megasync"},
+        "expect_min": 1,
+    },
+
+    # ── PASSIVE VOICE ──
+    {
+        "name": "passive_deployed_by",
+        "text": "Mimikatz was deployed by the BlackCat operators to dump LSASS.",
+        "entities": {"blackcat", "mimikatz", "lsass"},
+        "expect_min": 1,
+        "expect_source": "blackcat",
+        "expect_target": "mimikatz",
+    },
+    {
+        "name": "passive_used_by",
+        "text": "PsExec was used by the threat actor to execute ransomware on remote hosts.",
+        "entities": {"psexec"},
+        "expect_min": 1,
+        "expect_target": "psexec",
+    },
+    {
+        "name": "passive_exploited_by",
+        "text": "ConnectWise was exploited by ALPHV to gain initial access.",
+        "entities": {"alphv", "connectwise"},
+        "expect_min": 1,
+        "expect_source": "alphv",
+    },
+
+    # ── ONTOLOGY GROUNDING ──
+    {
+        "name": "no_entities_should_produce_nothing",
+        "text": "The researchers analyzed the sample in a sandbox environment.",
+        "entities": set(),
+        "expect_min": 0,
+        "expect_max": 0,
+    },
+    {
+        "name": "reporter_verb_should_be_skipped",
+        "text": "Symantec researchers identified Noberus as a new ransomware variant.",
+        "entities": {"noberus"},
+        "expect_min": 0,  # "identified" is a reporter verb
+    },
+
+    # ── DIVERSE THREAT ACTORS ──
+    {
+        "name": "turla_snake",
+        "text": "Turla leveraged the Snake implant for persistent access to government networks.",
+        "entities": {"turla", "snake"},
+        "expect_min": 1,
+        "expect_source": "turla",
+    },
+    {
+        "name": "muddywater_powershell",
+        "text": "MuddyWater executed PowerShell scripts to download additional payloads.",
+        "entities": {"muddywater", "powershell"},
+        "expect_min": 1,
+        "expect_source": "muddywater",
+    },
+    {
+        "name": "conti_ransomware",
+        "text": "Conti operators used BazarLoader to deliver the ransomware payload.",
+        "entities": {"conti", "bazarloader"},
+        "expect_min": 1,
+        "expect_source": "conti",
+    },
+
+    # ── COMPLEX SENTENCES ──
+    {
+        "name": "multi_clause",
+        "text": "After gaining initial access, Volt Typhoon used living-off-the-land binaries to move laterally.",
+        "entities": {"volt typhoon"},
+        "expect_min": 1,
+        "expect_source": "volt typhoon",
+    },
+    {
+        "name": "infrastructure_target",
+        "text": "The malware connects to the C2 server at evil.example.com on port 443.",
+        "entities": {"evil.example.com"},
+        "expect_min": 1,
+        "expect_target": "evil.example.com",
+    },
+]
+
+
+# ============================================================
+# TEST RUNNER
+# ============================================================
+
+def run_tests():
+    passed = 0
+    failed = 0
+    total = len(TEST_CASES)
+
+    print(f"Running {total} relationship extraction tests\n")
+    print(f"{'Test':<40} {'Result':>8} {'Found':>6} {'Expected':>9} {'Details'}")
+    print(f"{'-'*40} {'-'*8} {'-'*6} {'-'*9} {'-'*30}")
+
+    for tc in TEST_CASES:
+        name = tc["name"]
+        text = tc["text"]
+        entities = tc["entities"]
+        expect_min = tc.get("expect_min", 1)
+        expect_max = tc.get("expect_max", 999)
+        expect_source = tc.get("expect_source")
+        expect_target = tc.get("expect_target")
+        expect_contains = tc.get("expect_contains", [])
+
+        # Run extraction
+        triples = extract_triples(text, entities)
+        filtered = filter_grounded_relationships(triples)
+        deduped = dedup_triples(filtered)
+
+        # Evaluate
+        ok = True
+        details = []
+
+        if len(deduped) < expect_min:
+            ok = False
+            details.append(f"too few ({len(deduped)}<{expect_min})")
+
+        if len(deduped) > expect_max:
+            ok = False
+            details.append(f"too many ({len(deduped)}>{expect_max})")
+
+        if expect_source:
+            sources = {r["source"].lower() for r in deduped}
+            if not any(expect_source in s for s in sources):
+                ok = False
+                details.append(f"missing source '{expect_source}'")
+
+        if expect_target:
+            targets = {r["target"].lower() for r in deduped}
+            if not any(expect_target in t for t in targets):
+                ok = False
+                details.append(f"missing target '{expect_target}'")
+
+        for exp_src, exp_verb, exp_tgt in expect_contains:
+            found = False
+            for r in deduped:
+                if (exp_src in r["source"].lower() and
+                    exp_verb in r["relationship"] and
+                    exp_tgt in r["target"].lower()):
+                    found = True
+                    break
+            if not found:
+                ok = False
+                details.append(f"missing ({exp_src}→{exp_verb}→{exp_tgt})")
+
+        if ok:
+            passed += 1
+            status = "PASS"
+        else:
+            failed += 1
+            status = "FAIL"
+
+        detail_str = "; ".join(details) if details else ""
+        if deduped and not details:
+            # Show what we found
+            r = deduped[0]
+            detail_str = f"{r['source']}→{r['relationship']}→{r['target']}"
+
+        print(f"{name:<40} {status:>8} {len(deduped):>6} {f'>={expect_min}':>9} {detail_str}")
+
+    print(f"\n{'='*70}")
+    print(f"RESULTS: {passed}/{total} passed ({100*passed/total:.0f}%), {failed} failed")
+    print(f"{'='*70}")
+
+    return passed, failed
+
+
+if __name__ == "__main__":
+    passed, failed = run_tests()
+    sys.exit(1 if failed > 0 else 0)


### PR DESCRIPTION
## Summary
- Raise MITRE semantic similarity threshold (0.42→0.82) to eliminate false positive ATT&CK techniques
- Add explicit T-number regex extraction from all IR text fields
- Filter deprecated/revoked ATT&CK technique IDs from output
- Add deterministic entity reclassification using MITRE taxonomy (tools vs malware vs technique descriptions)
- Split slash-separated actor names into individual actors with alias metadata
- Preserve dots in IP addresses and domain names during entity canonicalization
- Fix use-before-assignment bug in relationship candidate creation (`cti_relationships.py:448`)
- Fix D3FEND enrichment path (doubled `plugins/mcp` prefix → now loads ontology correctly)
- Increase Ollama client timeout to 600s for longer documents

## Baseline test results (2/5 ALPHV BlackCat CTI reports)

| Metric | Before | After |
|--------|--------|-------|
| TTP Precision | 1% | 6% |
| TTP Recall | 3% | 6% |
| False Positive TTPs | 68 | 31 |
| Relationships | 2 | 6 |
| Actor aliases | ALPHV missing | ALPHV + BlackCat both present |
| D3FEND enrichment | BROKEN | Working (47 nodes, 232 edges) |

## Test plan
- [ ] Run full Stage 1+2 pipeline on ALPHV BlackCat CTI reports
- [ ] Verify STIX bundles pass `validate_bundle()`
- [ ] Verify D3FEND CAD graphs are generated
- [ ] Verify no deprecated ATT&CK IDs in output
- [ ] Verify actor aliases are correctly split