### PR TITLE
fix: use sys.executable instead of bare 'mlflow' binary in subprocess

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -61,8 +61,9 @@ if not is_port_open(5000):
         plugin_dir = os.path.dirname(os.path.abspath(__file__))
         mlruns_path = os.path.join(plugin_dir, 'mlruns')
         db_path = os.path.join(plugin_dir, 'mlruns.db')
+        import sys
         subprocess.Popen([
-            "mlflow", "server",
+            sys.executable, "-m", "mlflow", "server",
             "--backend-store-uri", f"sqlite:///{db_path}",
             "--default-artifact-root", mlruns_path,
             "--host", "127.0.0.1",


### PR DESCRIPTION
## Problem
When starting the MLflow server in `hook.py`, the plugin calls `"mlflow"` 
as a bare binary in `subprocess.Popen`. This fails with:

    FileNotFoundError: [Errno 2] No such file or directory: 'mlflow'

This happens when `mlflow` is installed in the user's local Python environment 
(e.g. `~/.local/lib/`) but is not on the system PATH used by the subprocess.

## Fix
Replace the bare `"mlflow"` call with `sys.executable, "-m", "mlflow"`, 
which uses the same Python interpreter that is already running Caldera. 
This guarantees mlflow is found regardless of PATH configuration.

## Before
    subprocess.Popen(["mlflow", "server", ...])

## After
    import sys
    subprocess.Popen([sys.executable, "-m", "mlflow", "server", ...])

## Tested on
- Ubuntu 22.04 / Python 3.10
- mlflow installed via pip (--break-system-packages)