### PR TITLE
chore(ci): add GitHub issue/PR templates and lint workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,15 @@
+[flake8]
+max-line-length = 180
+exclude =
+    .svn,
+    CVS,
+    .bzr,
+    .hg,
+    .git,
+    __pycache__,
+    .tox,
+    venv,
+    .venv,
+    data,
+    app/utilities/data,
+    app/utilities/cti_taxonomy

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: "\U0001F41E  Bug report"
+about: Create a report to help us improve
+title: ''
+labels: bug
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. 
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Mac, Windows, Kali]
+ - Browser [e.g. chrome, safari]
+ - Caldera version [e.g. 5.0.0]
+ - Python version [e.g. 3.12]
+ - MCP model/provider [e.g. ollama/llama3, openai/gpt-4o]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Documentation
+    url: https://caldera.readthedocs.io/en/latest/
+    about: Your question may be answered in the documentation

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,37 @@
+---
+name: "\U0001F680 New Feature Request"
+about: Propose a new feature
+title: ''
+labels: feature
+
+---
+
+**What problem are you trying to solve? Please describe.**
+> Eg. I'm always frustrated when [...]
+
+
+**The ideal solution: What should the feature should do?**
+> a clear and concise description
+
+
+**What category of feature is this?**
+
+- [ ] UI/UX
+- [ ] API
+- [ ] MCP server / tooling
+- [ ] CTI pipeline
+- [ ] Other
+
+**If you have code or pseudo-code please provide:**
+
+<!-- Put your code examples here -->
+```python
+
+```
+
+- [ ] Willing to submit a pull request to implement this feature?
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+
+Thank you for your contribution!

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,18 @@
+---
+name: "\U00002753 Question"
+about: Support questions
+title: ''
+labels: question
+
+---
+
+
+
+
+<!--
+Please see our documentation here: https://caldera.readthedocs.io/en/latest/
+
+Plugin-specific documentation lives in this repository: README.md and docs/mcp.md
+
+If you'd like to help us improve our documentation please open a pull request here: https://github.com/mitre/fieldmanual
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Description
+
+(insert summary)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes.
+
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,19 @@
+name: Greetings
+
+on: [pull_request, issues]
+
+permissions:
+  contents: read
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/first-interaction@1d8459ca65b335265f1285568221e229d45a995e
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-message: 'Looks like your first issue -- we aim to respond to issues as quickly as possible. In the meantime, check out our documentation here: http://caldera.readthedocs.io/'
+        pr-message: 'Wohoo! Your first PR -- thanks for contributing!'

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,34 @@
+name: python-lint
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Setup python
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: pip install flake8
+      # Hard gate: syntax errors only. F82 (undefined names) is left out
+      # because a dead legacy path in rag.py trips it; the wider sweep below
+      # is advisory until that and the existing style violations are cleared.
+      - name: Lint for errors
+        run: flake8 . --select=E9,F63,F7 --show-source --statistics
+      - name: Style report
+        run: flake8 . --exit-zero --statistics

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        stale-pr-message: 'This pull request is stale because it has had no activity for 60 days. Remove the stale label or comment or this will be closed in 60 days'
+        stale-issue-message: 'This issue is stale because it has had no activity for 60 days. Remove the stale label or comment or this will be closed in 60 days'
+        exempt-issue-labels: 'feature,keep'
+        days-before-stale: 60
+        days-before-close: 60


### PR DESCRIPTION
## Description

Ports the shared MITRE Caldera plugin `.github` baseline into this plugin, matching what mitre/training, stockpile, and atomic already use:

- `ISSUE_TEMPLATE/` (bug report, feature request, question, config)
- `pull_request_template.md`
- `workflows/greetings.yml` (first-interaction bot)
- `workflows/stale.yml` (60 day stale, 60 day close)

Action versions stay SHA pinned, as upstream has them. The `assignees:` front matter was dropped from all three issue templates so issues do not auto assign to an upstream maintainer.

Two adaptations for this repo:

**No JavaScript lint.** Training's `javascript-lint.yml` runs `npm ci && npm run lint`. There is no `package.json` or lockfile here, so that would fail on its first step. The Vue sources under `gui/` are consumed by Caldera's frontend rather than built as their own npm project. Replaced with `python-lint.yml`, which reflects what this plugin actually is.

**Lint gate is narrow on purpose.** The hard gate runs `flake8 --select=E9,F63,F7` (syntax errors). The full sweep runs with `--exit-zero` so it reports without blocking, since the existing tree has roughly 400 style findings. `F82` (undefined names) is left out of the gate for now: a dead legacy path in `app/capabilities/rag.py` trips it, and cleaning that up belongs in its own change. Add `F82` back to the gate once it is gone.

`.flake8` mirrors caldera core's own config (`max-line-length = 180`) plus excludes for the vendored data and taxonomy directories. Without it the advisory sweep reports 1419 findings against flake8's default 79 char limit instead of 399.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- `flake8 . --select=E9,F63,F7 --show-source --statistics` exits 0 against this branch, so the gate is green on first run.
- All four workflow and config YAML files parse with `yaml.safe_load`.
- Advisory sweep confirmed to report without failing the job.

No test workflow is included yet. `tests/test_relation_extractor.py` imports `plugins.mcp.app.utilities.cti_relation_extractor`, which no longer exists, so pytest currently fails at collection. Worth fixing separately before adding a test job.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works