### PR TITLE
refactor(config)!: consolidate LLM credential resolution and remove the vendor endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,12 @@
 # Copy this file to .env and fill in values. .env is gitignored.
 
-# LLM provider key
-# Paste your key from OpenAI / MITRE gateway / etc. Required unless every
-# request supplies its own key via the UI's Global Model Configuration.
+# OpenAI-compatible API root, e.g. https://api.openai.com/v1. Required:
+# none ships in conf/default.yml, and an unresolved value is refused
+# rather than defaulting to public OpenAI.
+MCP_LLM_API_BASE=
+
+# Key for whichever provider MCP_LLM_API_BASE points at. Required unless
+# every request supplies its own via the UI's Global Model Configuration.
 MCP_LLM_API_KEY=
 
 # Caldera REST API

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ CTI/RAG model settings can use the chat endpoint by default or a separate saved 
 
 Prefer environment variables for local values, and keep `conf/default.yml` limited to safe defaults.
 
-To pin values on disk instead, copy `conf/default.yml` to `conf/local.yml` and edit that. **`local.yml` replaces `default.yml` rather than merging with it**, so a partial file silently drops every key it omits, including the `api_key_env` and `api_base_env` indirection that makes the environment variables work.
+To pin values on disk instead, set them in `conf/local.yml`. That file is overlaid onto `conf/default.yml` key by key, so it only needs the keys it changes.
 
 The `llm` block sits at the top level of the file:
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,18 @@ source venv/bin/activate
 pip install -r plugins/mcp/requirements.txt
 ```
 
-5. Configure model credentials through the UI or environment/local config. Avoid committing secrets.
+5. Copy `.env.example` to `.env` and set the LLM endpoint and credential. Both are required; nothing ships in `conf/default.yml`.
+
+```bash
+cp plugins/mcp/.env.example plugins/mcp/.env
+```
+
+| Variable | Purpose |
+|---|---|
+| `MCP_LLM_API_BASE` | OpenAI-compatible API root, for example `https://api.openai.com/v1`. An unresolved value is refused rather than defaulting to public OpenAI. |
+| `MCP_LLM_API_KEY` | Key for whichever provider `MCP_LLM_API_BASE` points at. Optional only if every request supplies its own through the UI. |
+
+Both may instead be supplied per-session through the UI's Global Model Configuration. Avoid committing secrets.
 
 ## Quick Start
 
@@ -184,22 +195,24 @@ CTI/RAG model settings can use the chat endpoint by default or a separate saved 
 
 ### Local Settings
 
-Use `conf/local.yml` or environment variables for local values. Keep `conf/default.yml` limited to safe defaults.
+Prefer environment variables for local values, and keep `conf/default.yml` limited to safe defaults.
 
-Common values include:
+To pin values on disk instead, copy `conf/default.yml` to `conf/local.yml` and edit that. **`local.yml` replaces `default.yml` rather than merging with it**, so a partial file silently drops every key it omits, including the `api_key_env` and `api_base_env` indirection that makes the environment variables work.
+
+The `llm` block sits at the top level of the file:
 
 ```yaml
-mcp:
-  llm:
-    model: openai/gpt-oss-120b
-    api_base: https://api.example.com/v1
-    api_key: ''
-    temperature: 0.5
-    max_tool_calls: 5
-    max_tokens: 24000
+llm:
+  model: openai/gpt-oss-120b
+  api_base: https://api.example.com/v1
+  api_base_env: MCP_LLM_API_BASE
+  api_key_env: MCP_LLM_API_KEY
+  temperature: 0.5
+  max_tool_calls: 5
+  max_tokens: 24000
 ```
 
-Environment variables can also be used by deployments that prefer not to store secrets in YAML.
+A value set here outranks the environment variable named beside it, so leave `api_base` empty to keep resolving it from `MCP_LLM_API_BASE`. The `cti` block takes the same shape and may name a different variable if CTI extraction should reach a separate endpoint.
 
 ## API Surface
 

--- a/app/config.py
+++ b/app/config.py
@@ -55,6 +55,21 @@ _BOOLEAN_FALLBACKS = {
 }
 
 
+def _resolve_api_base(cfg: dict) -> str:
+    """Yaml api_base, falling back to the env var named by api_base_env.
+
+    Consumes the api_base_env key so it never leaks into the settings dict
+    handed to DSPy. Whitespace is stripped here because
+    normalize_openai_api_base treats a blank-but-truthy string as a real
+    URL and would turn it into the relative path "/v1".
+    """
+    configured = str(cfg.pop('api_base', '') or '').strip()
+    env_var = cfg.pop('api_base_env', None)
+    if configured:
+        return configured
+    return os.environ.get(env_var, '').strip() if env_var else ''
+
+
 def _load_defaults() -> dict:
     """Returns the parsed yaml file as a dict. Empty dict on failure."""
     try:
@@ -90,14 +105,15 @@ def mlflow_settings() -> dict:
 
 
 def llm_defaults() -> dict:
-    """Resolve the LLM block: yaml shape plus api_key from its env var.
+    """Resolve the LLM block: yaml shape plus api_key/api_base from env vars.
 
-    api_key is empty string when the env var is unset; the caller decides
-    whether that is fatal.
+    api_key and api_base are empty strings when their env vars are unset;
+    the caller decides whether that is fatal.
     """
     cfg = dict(_load_defaults().get('llm') or {})
     env_var = cfg.pop('api_key_env', None)
     cfg['api_key'] = os.environ.get(env_var, '') if env_var else cfg.get('api_key', '') or ''
+    cfg['api_base'] = _resolve_api_base(cfg)
     if cfg.get('provider', 'openai_compatible') == 'openai_compatible':
         cfg['api_base'] = normalize_openai_api_base(cfg.get('api_base'))
     cfg.setdefault('provider', 'openai_compatible')
@@ -205,8 +221,9 @@ def resolve_llm_config(ui_overrides: dict | None) -> dict:
     entirely; the UI also disables those inputs client-side via the
     /defaults endpoint.
 
-    Raises ValueError when no api_key can be resolved from any tier so
-    callers fail loudly instead of attempting an unauthenticated LLM call.
+    Raises ValueError when no api_key or api_base can be resolved from any
+    tier so callers fail loudly instead of attempting an unauthenticated
+    LLM call or silently reaching a provider the deployment never chose.
     """
     base = llm_defaults()
     locked = base.get('fields_locked') or {}
@@ -228,4 +245,13 @@ def resolve_llm_config(ui_overrides: dict | None) -> dict:
         )
     if merged.get('provider', 'openai_compatible') == 'openai_compatible':
         merged['api_base'] = normalize_openai_api_base(merged.get('api_base'))
+        # dspy_lm_kwargs_from_settings drops a falsy api_base entirely, which
+        # makes LiteLLM route openai/* models to https://api.openai.com/v1.
+        # Refuse rather than silently egress to an unintended provider.
+        if not merged.get('api_base'):
+            raise ValueError(
+                "No LLM api_base. Set MCP_LLM_API_BASE in plugins/mcp/.env, "
+                "pin llm.api_base in conf/local.yml, or enter one in the "
+                "UI's Global Model Configuration."
+            )
     return merged

--- a/app/config.py
+++ b/app/config.py
@@ -208,8 +208,9 @@ def caldera_connection() -> dict:
 def resolve_llm_config(ui_overrides: dict | None) -> dict:
     """Merge yaml defaults, .env credential, and UI overrides.
 
-    Empty / None UI fields do not override defaults (clearing the UI field
-    is the natural way for a user to fall back to the server default).
+    Empty, whitespace-only and None UI fields do not override defaults
+    (clearing the UI field is the natural way for a user to fall back to
+    the server default).
     Fields declared fields_locked: true in yaml ignore UI overrides
     entirely; the UI also disables those inputs client-side via the
     /defaults endpoint.
@@ -222,11 +223,17 @@ def resolve_llm_config(ui_overrides: dict | None) -> dict:
     """
     base = llm_defaults()
     locked = base.get('fields_locked') or {}
-    overrides = {
-        key: value
-        for key, value in (ui_overrides or {}).items()
-        if value not in ("", None) and not locked.get(key, False)
-    }
+    # Strings are stripped before the emptiness test so a field the user
+    # only put spaces in falls back to the server default like a cleared
+    # one. Without this an api_base of "   " is truthy, normalizes to the
+    # relative path "/v1", and satisfies the guard below.
+    overrides = {}
+    for key, value in (ui_overrides or {}).items():
+        if isinstance(value, str):
+            value = value.strip()
+        if value in ("", None) or locked.get(key, False):
+            continue
+        overrides[key] = value
     merged = {**base, **overrides}
     for key in _BOOLEAN_FALLBACKS:
         if key in merged:

--- a/app/config.py
+++ b/app/config.py
@@ -94,15 +94,10 @@ def mlflow_settings() -> dict:
 
 
 def profile_defaults(profile: str = 'llm') -> dict:
-    """Resolve one LLM profile from yaml: shape plus env-resolved credentials.
+    """Resolve one LLM profile: yaml shape plus env-resolved credentials.
 
-    Every profile in the yaml shares one shape, so credential resolution is
-    delegated to llm_client.resolve_env_indirection rather than reimplemented
-    here. That keeps the parent-side resolver and the provenance path used by
-    the CTI pipeline reading `api_key_env` / `api_base_env` identically.
-
-    api_key and api_base are empty strings when neither yaml nor env supplies
-    one; the caller decides whether that is fatal.
+    api_key and api_base are empty when unresolved; the caller decides
+    whether that is fatal.
     """
     cfg = resolve_env_indirection(_load_defaults().get(profile) or {})
     cfg.setdefault('fields_locked', {})
@@ -223,10 +218,8 @@ def resolve_llm_config(ui_overrides: dict | None) -> dict:
     """
     base = llm_defaults()
     locked = base.get('fields_locked') or {}
-    # Strings are stripped before the emptiness test so a field the user
-    # only put spaces in falls back to the server default like a cleared
-    # one. Without this an api_base of "   " is truthy, normalizes to the
-    # relative path "/v1", and satisfies the guard below.
+    # Strip first: an api_base of "   " is truthy and normalizes to the
+    # relative path "/v1", which would satisfy the guard below.
     overrides = {}
     for key, value in (ui_overrides or {}).items():
         if isinstance(value, str):
@@ -245,12 +238,8 @@ def resolve_llm_config(ui_overrides: dict | None) -> dict:
             "No LLM API key. Set MCP_LLM_API_KEY in plugins/mcp/.env or "
             "enter one in the UI's Global Model Configuration."
         )
-    # provider arrives from the request body unvalidated, so normalize it
-    # before branching. Only the normalization is provider-specific; the
-    # api_base requirement is not. dspy_lm_kwargs_from_settings drops a
-    # falsy api_base entirely, which leaves LiteLLM routing openai/* models
-    # to https://api.openai.com/v1 no matter what provider the caller named,
-    # and the ollama path needs a base to post to just as much.
+    # provider is unvalidated request input, so normalize before branching.
+    # Only normalization is provider-specific; every provider needs a base.
     provider = merged.get('provider') or 'openai_compatible'
     merged['provider'] = provider
     if provider == 'openai_compatible':

--- a/app/config.py
+++ b/app/config.py
@@ -217,6 +217,8 @@ def resolve_llm_config(ui_overrides: dict | None) -> dict:
     Raises ValueError when no api_key or api_base can be resolved from any
     tier so callers fail loudly instead of attempting an unauthenticated
     LLM call or silently reaching a provider the deployment never chose.
+    Both checks apply to every provider, including ones this plugin does
+    not recognize.
     """
     base = llm_defaults()
     locked = base.get('fields_locked') or {}
@@ -236,15 +238,20 @@ def resolve_llm_config(ui_overrides: dict | None) -> dict:
             "No LLM API key. Set MCP_LLM_API_KEY in plugins/mcp/.env or "
             "enter one in the UI's Global Model Configuration."
         )
-    if merged.get('provider', 'openai_compatible') == 'openai_compatible':
-        merged['api_base'] = normalize_openai_api_base(merged.get('api_base'))
-        # dspy_lm_kwargs_from_settings drops a falsy api_base entirely, which
-        # makes LiteLLM route openai/* models to https://api.openai.com/v1.
-        # Refuse rather than silently egress to an unintended provider.
-        if not merged.get('api_base'):
-            raise ValueError(
-                "No LLM api_base. Set MCP_LLM_API_BASE in plugins/mcp/.env, "
-                "pin llm.api_base in conf/local.yml, or enter one in the "
-                "UI's Global Model Configuration."
-            )
+    # provider arrives from the request body unvalidated, so normalize it
+    # before branching. Only the normalization is provider-specific; the
+    # api_base requirement is not. dspy_lm_kwargs_from_settings drops a
+    # falsy api_base entirely, which leaves LiteLLM routing openai/* models
+    # to https://api.openai.com/v1 no matter what provider the caller named,
+    # and the ollama path needs a base to post to just as much.
+    provider = merged.get('provider') or 'openai_compatible'
+    merged['provider'] = provider
+    if provider == 'openai_compatible':
+        merged['api_base'] = normalize_openai_api_base(merged.get('api_base')) or ''
+    if not merged.get('api_base'):
+        raise ValueError(
+            "No LLM api_base. Set MCP_LLM_API_BASE in plugins/mcp/.env, "
+            "copy conf/default.yml to conf/local.yml and pin llm.api_base "
+            "there, or enter one in the UI's Global Model Configuration."
+        )
     return merged

--- a/app/config.py
+++ b/app/config.py
@@ -30,7 +30,11 @@ import os
 
 from app.utility.base_world import BaseWorld
 from plugins.mcp.app.dspy_env import coerce_optional_bool
-from plugins.mcp.app.utilities.llm_client import load_config, normalize_openai_api_base
+from plugins.mcp.app.utilities.llm_client import (
+    load_config,
+    normalize_openai_api_base,
+    resolve_env_indirection,
+)
 
 
 _YAML_PATH = 'plugins/mcp/conf/default.yml'
@@ -53,21 +57,6 @@ _NUMERIC_FALLBACKS = {
 _BOOLEAN_FALLBACKS = {
     "ssl_verify": True,
 }
-
-
-def _resolve_api_base(cfg: dict) -> str:
-    """Yaml api_base, falling back to the env var named by api_base_env.
-
-    Consumes the api_base_env key so it never leaks into the settings dict
-    handed to DSPy. Whitespace is stripped here because
-    normalize_openai_api_base treats a blank-but-truthy string as a real
-    URL and would turn it into the relative path "/v1".
-    """
-    configured = str(cfg.pop('api_base', '') or '').strip()
-    env_var = cfg.pop('api_base_env', None)
-    if configured:
-        return configured
-    return os.environ.get(env_var, '').strip() if env_var else ''
 
 
 def _load_defaults() -> dict:
@@ -104,19 +93,18 @@ def mlflow_settings() -> dict:
     }
 
 
-def llm_defaults() -> dict:
-    """Resolve the LLM block: yaml shape plus api_key/api_base from env vars.
+def profile_defaults(profile: str = 'llm') -> dict:
+    """Resolve one LLM profile from yaml: shape plus env-resolved credentials.
 
-    api_key and api_base are empty strings when their env vars are unset;
-    the caller decides whether that is fatal.
+    Every profile in the yaml shares one shape, so credential resolution is
+    delegated to llm_client.resolve_env_indirection rather than reimplemented
+    here. That keeps the parent-side resolver and the provenance path used by
+    the CTI pipeline reading `api_key_env` / `api_base_env` identically.
+
+    api_key and api_base are empty strings when neither yaml nor env supplies
+    one; the caller decides whether that is fatal.
     """
-    cfg = dict(_load_defaults().get('llm') or {})
-    env_var = cfg.pop('api_key_env', None)
-    cfg['api_key'] = os.environ.get(env_var, '') if env_var else cfg.get('api_key', '') or ''
-    cfg['api_base'] = _resolve_api_base(cfg)
-    if cfg.get('provider', 'openai_compatible') == 'openai_compatible':
-        cfg['api_base'] = normalize_openai_api_base(cfg.get('api_base'))
-    cfg.setdefault('provider', 'openai_compatible')
+    cfg = resolve_env_indirection(_load_defaults().get(profile) or {})
     cfg.setdefault('fields_locked', {})
     for key, fallback in _NUMERIC_FALLBACKS.items():
         cfg.setdefault(key, fallback)
@@ -124,6 +112,11 @@ def llm_defaults() -> dict:
         value = coerce_optional_bool(cfg.get(key))
         cfg[key] = fallback if value is None else value
     return cfg
+
+
+def llm_defaults() -> dict:
+    """The `llm` profile: the default for chat and workflow execution."""
+    return profile_defaults('llm')
 
 
 def _normalise_api_url(url: str) -> str:

--- a/app/config.py
+++ b/app/config.py
@@ -1,29 +1,33 @@
 """Parent-side configuration resolver.
 
-Two credentials, three tiers, one resolver:
+Three env-resolved values, three tiers, one resolver:
 
-  CORE_CALDERA_API_KEY   env only. Authenticates the caldera_core MCP
-                         subprocess to the running Caldera REST API.
-  MCP_LLM_API_KEY        env default plus per-session UI override.
-                         Authenticates DSPy / signatures / embeddings to
+  CORE_CALDERA_API_KEY   Authenticates the caldera_core MCP subprocess to
+                         the running Caldera REST API.
+  MCP_LLM_API_KEY        Authenticates DSPy / signatures / embeddings to
                          the LLM provider.
+  MCP_LLM_API_BASE       The OpenAI-compatible endpoint they reach. No
+                         default ships; an unresolved value is refused
+                         rather than falling back to public OpenAI.
 
 Storage tiers:
 
-  conf/default.yml carries non-secret defaults and names of env vars to
-  consult. It never holds credential values.
+  conf/default.yml carries non-secret defaults and the names of env vars
+  to consult. It never holds credential values, and neither does the
+  conf/local.yml the UI writes: set_config strips secrets on save.
 
   .env carries credential values. It is gitignored. The plugin's hook.py
   loads it once in the parent process; subprocesses inherit.
 
-  The UI submits per-session overrides on each /execute request and never
-  writes back to disk.
+  The UI submits per-session overrides on each /execute request.
 
 Resolution order for an LLM request:
 
   1. yaml defaults (model, api_base, temperature, ...)
-  2. env-resolved api_key (read from the env var named in api_key_env)
-  3. UI overrides (only non-empty fields, only fields not declared
+  2. env indirection, per llm_client.ENV_INDIRECT_FIELDS. Secrets resolve
+     env-first so rotating .env takes effect; endpoints resolve yaml-first
+     so a deployment can pin one on disk.
+  3. UI overrides (non-empty fields only, and only fields not declared
      fields_locked: true in yaml)
 """
 import os

--- a/app/config.py
+++ b/app/config.py
@@ -13,8 +13,8 @@ Three env-resolved values, three tiers, one resolver:
 Storage tiers:
 
   conf/default.yml carries non-secret defaults and the names of env vars
-  to consult. It never holds credential values, and neither does the
-  conf/local.yml the UI writes: set_config strips secrets on save.
+  to consult. conf/local.yml is overlaid onto it key by key. Neither holds
+  credential values: set_config strips secrets before writing local.yml.
 
   .env carries credential values. It is gitignored. The plugin's hook.py
   loads it once in the parent process; subprocesses inherit.
@@ -251,7 +251,7 @@ def resolve_llm_config(ui_overrides: dict | None) -> dict:
     if not merged.get('api_base'):
         raise ValueError(
             "No LLM api_base. Set MCP_LLM_API_BASE in plugins/mcp/.env, "
-            "copy conf/default.yml to conf/local.yml and pin llm.api_base "
-            "there, or enter one in the UI's Global Model Configuration."
+            "pin llm.api_base in conf/local.yml, or enter one in the UI's "
+            "Global Model Configuration."
         )
     return merged

--- a/app/cti_pipeline_stage1.py
+++ b/app/cti_pipeline_stage1.py
@@ -191,7 +191,7 @@ def step_parse_to_ir(base_dir: Path, stop_after: str | None = None):
     _preload_thread_shared_nlp_resources()
 
     # Stage1 work is LLM/IO-bound, not CPU-bound: each file makes
-    # remote calls to the AIP gateway, downloads embeddings, reads
+    # remote calls to the LLM gateway, downloads embeddings, reads
     # taxonomy data, etc. Use ThreadPoolExecutor instead of
     # ProcessPoolExecutor so we don't fork-from-a-multithreaded
     # FastMCP process (which deadlocks the workers — they inherit

--- a/app/dspy_env.py
+++ b/app/dspy_env.py
@@ -70,14 +70,34 @@ def apply_litellm_ssl_verify(value):
 
 
 def dspy_lm_kwargs_from_settings(settings: dict) -> dict:
-    """Translate resolved MCP LLM settings into DSPy/LiteLLM kwargs."""
+    """Translate resolved MCP LLM settings into DSPy/LiteLLM kwargs.
+
+    Raises ValueError when no api_base survived resolution. Every dspy.LM()
+    in this plugin is built from kwargs this function returns, so it is the
+    one place that can guarantee LiteLLM never falls back to its built-in
+    https://api.openai.com/v1. config.resolve_llm_config raises earlier
+    with friendlier remediation text; this is the backstop for the callers
+    that never pass through it.
+
+    The check is deliberately not conditioned on provider: an empty base is
+    unusable for ollama too, and an unrecognized provider must not read as
+    permission to skip validation.
+    """
     settings = settings or {}
+    model = settings.get("model") or _DEFAULTS["model"]
+    api_base = str(settings.get("api_base") or "").strip()
+    if not api_base:
+        raise ValueError(
+            f"Refusing to build an LM for {model} with no api_base: LiteLLM "
+            "would route it to the built-in https://api.openai.com/v1 and "
+            "send the prompt and api_key to a provider this deployment "
+            "never chose. Set MCP_LLM_API_BASE in plugins/mcp/.env."
+        )
     lm_kwargs = {
-        "model": settings.get("model") or _DEFAULTS["model"],
+        "model": model,
         "api_key": settings.get("api_key") or "",
+        "api_base": api_base,
     }
-    if settings.get("api_base"):
-        lm_kwargs["api_base"] = settings.get("api_base")
     if settings.get("temperature") is not None:
         lm_kwargs["temperature"] = settings.get("temperature")
     if settings.get("max_tokens") is not None:
@@ -86,7 +106,7 @@ def dspy_lm_kwargs_from_settings(settings: dict) -> dict:
         lm_kwargs["timeout"] = settings.get("timeout")
 
     provider = settings.get("provider") or "openai_compatible"
-    if provider == "openai_compatible" and settings.get("api_base"):
+    if provider == "openai_compatible":
         lm_kwargs["custom_llm_provider"] = "custom_openai"
 
     apply_litellm_ssl_verify(settings.get("ssl_verify"))

--- a/app/dspy_env.py
+++ b/app/dspy_env.py
@@ -72,16 +72,9 @@ def apply_litellm_ssl_verify(value):
 def dspy_lm_kwargs_from_settings(settings: dict) -> dict:
     """Translate resolved MCP LLM settings into DSPy/LiteLLM kwargs.
 
-    Raises ValueError when no api_base survived resolution. Every dspy.LM()
-    in this plugin is built from kwargs this function returns, so it is the
-    one place that can guarantee LiteLLM never falls back to its built-in
-    https://api.openai.com/v1. config.resolve_llm_config raises earlier
-    with friendlier remediation text; this is the backstop for the callers
-    that never pass through it.
-
-    The check is deliberately not conditioned on provider: an empty base is
-    unusable for ollama too, and an unrecognized provider must not read as
-    permission to skip validation.
+    Raises ValueError without an api_base. Every dspy.LM() in the plugin is
+    built from these kwargs, so this is the one place that can guarantee
+    LiteLLM never falls back to https://api.openai.com/v1.
     """
     settings = settings or {}
     model = settings.get("model") or _DEFAULTS["model"]

--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -28,6 +28,19 @@ _RAG_DEFAULTS = {
 # never go in it. They come from .env or the per-session UI.
 _SECRET_FIELDS = ("api_key", "embed_api_key", "rag_api_key")
 
+
+def _without_secrets(value):
+    """Recursive: callers have posted nested shapes, so one level is not enough."""
+    if isinstance(value, dict):
+        return {
+            k: _without_secrets(v)
+            for k, v in value.items()
+            if k not in _SECRET_FIELDS
+        }
+    if isinstance(value, list):
+        return [_without_secrets(v) for v in value]
+    return value
+
 class McpAPI:
 
     def __init__(self, services):
@@ -957,13 +970,9 @@ class McpAPI:
                 if isinstance(cfg, dict):
                     existing[section] = cfg
 
-            # 3️⃣ Scrub secrets from every section, not just the posted ones,
-            # so a save also clears a key an earlier build already wrote.
-            for section, cfg in existing.items():
-                if isinstance(cfg, dict):
-                    existing[section] = {
-                        k: v for k, v in cfg.items() if k not in _SECRET_FIELDS
-                    }
+            # 3️⃣ Scrub secrets from the whole file, not just the posted
+            # sections, so a save also clears a key an earlier build wrote.
+            existing = _without_secrets(existing)
 
             # 4️⃣ Write merged config back
             with local_path.open("w", encoding="utf-8") as f:

--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from datetime import datetime
 
 from plugins.mcp.app.config import llm_defaults
-from plugins.mcp.app.utilities.llm_client import load_config
+from plugins.mcp.app.utilities.llm_client import load_config, reload_config
 from plugins.mcp.app.utilities.paths import get_mcp_data_dir, get_mcp_root
 from plugins.mcp.app.cti_ingest_svc import CTIIngestService
 
@@ -23,6 +23,10 @@ _RAG_DEFAULTS = {
     "rag_embed_model": "openai/text-embedding-3-small",
     "rag_topk": 5,
 }
+
+# conf/local.yml is plaintext on disk beside tracked config, so credentials
+# never go in it. They come from .env or the per-session UI.
+_SECRET_FIELDS = ("api_key", "embed_api_key", "rag_api_key")
 
 class McpAPI:
 
@@ -953,12 +957,21 @@ class McpAPI:
                 if isinstance(cfg, dict):
                     existing[section] = cfg
 
-            # 3️⃣ Write merged config back
+            # 3️⃣ Scrub secrets from every section, not just the posted ones,
+            # so a save also clears a key an earlier build already wrote.
+            for section, cfg in existing.items():
+                if isinstance(cfg, dict):
+                    existing[section] = {
+                        k: v for k, v in cfg.items() if k not in _SECRET_FIELDS
+                    }
+
+            # 4️⃣ Write merged config back
             with local_path.open("w", encoding="utf-8") as f:
                 yaml.safe_dump(existing, f, sort_keys=False)
 
-            # 4️⃣ Reload effective config in memory
-            self.services["config"] = load_config()
+            # 5️⃣ Reload effective config. load_config is lru_cached, so the
+            # cache must be cleared or this reads back the pre-write contents.
+            self.services["config"] = reload_config()
 
             self.log.info(f"[MCP] Config updated in {conf_dir}/local.yml")
 

--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -1,5 +1,6 @@
 from aiohttp import web
 import logging
+import re
 import mlflow
 import os
 import json
@@ -26,17 +27,20 @@ _RAG_DEFAULTS = {
 
 # conf/local.yml is plaintext on disk beside tracked config, so credentials
 # never go in it. They come from .env or the per-session UI.
-_SECRET_FIELDS = ("api_key", "embed_api_key", "rag_api_key")
+# Matched by name rather than listed: the UI keeps growing key fields
+# (embed_api_key, plan_api_key, cti_rag_api_key) and a list keeps missing them.
+# api_key_env names a variable, not a value, so it is kept.
+_SECRET_KEY_NAME = re.compile(r"api_?key", re.IGNORECASE)
+
+
+def _is_secret(name) -> bool:
+    return bool(_SECRET_KEY_NAME.search(str(name))) and not str(name).endswith("_env")
 
 
 def _without_secrets(value):
     """Recursive: callers have posted nested shapes, so one level is not enough."""
     if isinstance(value, dict):
-        return {
-            k: _without_secrets(v)
-            for k, v in value.items()
-            if k not in _SECRET_FIELDS
-        }
+        return {k: _without_secrets(v) for k, v in value.items() if not _is_secret(k)}
     if isinstance(value, list):
         return [_without_secrets(v) for v in value]
     return value

--- a/app/mcp_gui.py
+++ b/app/mcp_gui.py
@@ -50,6 +50,19 @@ class McpGUI(BaseWorld):
         except Exception:
             caldera = {}
 
+        # An api_key alone stopped being a complete precondition once
+        # api_base moved out of the shipped yaml: without a base LiteLLM
+        # routes to its own default, so the resolver refuses the run. Both
+        # have to be present before this page may claim to be configured.
+        llm_missing_env = [
+            env_var
+            for env_var, value in (
+                ("MCP_LLM_API_KEY", llm.get("api_key")),
+                ("MCP_LLM_API_BASE", llm.get("api_base")),
+            )
+            if not value
+        ]
+
         servers = getattr(mcp_svc, "server_registry", None) or {}
         workflows = getattr(mcp_svc, "workflow_registry", None) or {}
         capabilities = getattr(mcp_svc, "capability_registry", None) or {}
@@ -57,10 +70,10 @@ class McpGUI(BaseWorld):
         return {
             "name": self.name,
             "description": self.description,
-            "llm_configured": bool(llm.get("api_key")),
+            "llm_configured": not llm_missing_env,
+            "llm_missing_env": llm_missing_env,
             "llm_model": llm.get("model") or "",
             "llm_api_base": llm.get("api_base") or "",
-            "llm_api_key_env": "MCP_LLM_API_KEY",
             "caldera_url": caldera.get("url") or "",
             "caldera_api_key_env": caldera.get("api_key_env") or "CORE_CALDERA_API_KEY",
             "server_names": sorted(servers.keys()),

--- a/app/mcp_gui.py
+++ b/app/mcp_gui.py
@@ -50,10 +50,8 @@ class McpGUI(BaseWorld):
         except Exception:
             caldera = {}
 
-        # An api_key alone stopped being a complete precondition once
-        # api_base moved out of the shipped yaml: without a base LiteLLM
-        # routes to its own default, so the resolver refuses the run. Both
-        # have to be present before this page may claim to be configured.
+        # api_key alone stopped being a complete precondition when api_base
+        # left the shipped yaml: without a base the resolver refuses the run.
         llm_missing_env = [
             env_var
             for env_var, value in (

--- a/app/mcp_svc.py
+++ b/app/mcp_svc.py
@@ -373,8 +373,19 @@ class MCPService(BaseService):
         # below uses `mlflow.start_run(run_id=...)` in its own context
         # manager, which is per-task and doesn't conflict.
         from mlflow.tracking import MlflowClient as _Mlc
+        # The workflow module creates this on its first run(), which is after
+        # this lookup, so mint it here rather than filing the run under
+        # Default. create_experiment not set_experiment: the latter would
+        # mutate the process-wide active experiment this block avoids.
         _exp = mlflow.get_experiment_by_name("caldera-mcp-client-1")
-        _exp_id = _exp.experiment_id if _exp else "0"
+        if _exp is not None:
+            _exp_id = _exp.experiment_id
+        else:
+            try:
+                _exp_id = _Mlc().create_experiment("caldera-mcp-client-1")
+            except Exception:
+                _exp = mlflow.get_experiment_by_name("caldera-mcp-client-1")
+                _exp_id = _exp.experiment_id if _exp else "0"
         run = _Mlc().create_run(
             experiment_id=_exp_id,
             tags={"mlflow.runName": f"MCP {workflow.display_name}"},

--- a/app/utilities/llm_client.py
+++ b/app/utilities/llm_client.py
@@ -101,6 +101,21 @@ def normalize_openai_api_base(api_base: str | None) -> str | None:
     return urlunsplit((parts.scheme, parts.netloc, path, parts.query, parts.fragment))
 
 
+def resolve_api_base(llm_cfg: dict) -> str:
+    """Yaml api_base for a profile, else the env var named by api_base_env.
+
+    Keeps the shipped yaml free of any deployment's gateway hostname while
+    letting both the `llm` and `cti` profiles read one env var. Whitespace
+    is stripped because normalize_openai_api_base treats a blank-but-truthy
+    string as a real URL and would turn it into the relative path "/v1".
+    """
+    configured = str((llm_cfg or {}).get("api_base") or "").strip()
+    if configured:
+        return configured
+    env_var = (llm_cfg or {}).get("api_base_env")
+    return os.environ.get(env_var, "").strip() if env_var else ""
+
+
 def _aiohttp_ssl_arg(ssl_verify):
     """Return aiohttp's per-request SSL argument for MCP LLM config."""
     verify = coerce_optional_bool(ssl_verify)
@@ -145,7 +160,7 @@ def get_llm_provenance(profile: str = "llm", *, runtime: bool = False) -> dict:
 
     # Runtime-only fields (do NOT log these)
     base["api_key"] = llm.get("api_key")
-    base["api_base"] = llm.get("api_base")
+    base["api_base"] = resolve_api_base(llm)
     if base["provider"] == "openai_compatible":
         base["api_base"] = normalize_openai_api_base(base["api_base"])
 
@@ -198,7 +213,7 @@ class LLMClient:
             return None
 
         model = llm_cfg.get("model")
-        api_base = llm_cfg.get("api_base")
+        api_base = resolve_api_base(llm_cfg)
         temperature = llm_cfg.get("temperature", 0.0)
 
         if not model or not api_base:

--- a/app/utilities/llm_client.py
+++ b/app/utilities/llm_client.py
@@ -60,28 +60,42 @@ def init_mlflow(profile: str):
 # Config loader (local, explicit, deterministic)
 # ------------------------------------------------------
 
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Overlay override onto base, recursing into nested dicts."""
+    merged = dict(base)
+    for key, value in (override or {}).items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
 @lru_cache(maxsize=1)
 def load_config() -> dict:
-    """
-    Load effective config with precedence:
-    1. conf/local.yml (if present)
-    2. conf/default.yml
+    """conf/default.yml overlaid with conf/local.yml, key by key.
 
-    This function is deterministic and cached.
+    local.yml used to replace default.yml wholesale, so a partial file, which
+    is what the UI's Save writes, dropped the api_key_env / api_base_env keys
+    and silently disabled .env resolution for the whole deployment.
+
+    Deterministic and cached; call reload_config() after writing local.yml.
     """
     root_dir = get_mcp_root()
     default_path = root_dir / "conf" / "default.yml"
     local_path = root_dir / "conf" / "local.yml"
 
-    if local_path.exists():
-        with local_path.open("r", encoding="utf-8") as f:
-            return yaml.safe_load(f) or {}
-
+    config = {}
     if default_path.exists():
         with default_path.open("r", encoding="utf-8") as f:
-            return yaml.safe_load(f) or {}
+            config = yaml.safe_load(f) or {}
+    if local_path.exists():
+        with local_path.open("r", encoding="utf-8") as f:
+            config = _deep_merge(config, yaml.safe_load(f) or {})
 
-    raise FileNotFoundError("No config found (default.yml or local.yml)")
+    if not config:
+        raise FileNotFoundError("No config found (default.yml or local.yml)")
+    return config
 
 def reload_config():
     """Force reload MCP config from disk."""

--- a/app/utilities/llm_client.py
+++ b/app/utilities/llm_client.py
@@ -189,7 +189,7 @@ def get_llm_provenance(profile: str = "llm", *, runtime: bool = False) -> dict:
 
     if not base["api_key"]:
         raise ValueError(f"{profile}.api_key missing from MCP config")
-    if base["provider"] == "openai_compatible" and not base["api_base"]:
+    if not base["api_base"]:
         raise ValueError(f"{profile}.api_base missing from MCP config")
 
     return base

--- a/app/utilities/llm_client.py
+++ b/app/utilities/llm_client.py
@@ -101,19 +101,45 @@ def normalize_openai_api_base(api_base: str | None) -> str | None:
     return urlunsplit((parts.scheme, parts.netloc, path, parts.query, parts.fragment))
 
 
-def resolve_api_base(llm_cfg: dict) -> str:
-    """Yaml api_base for a profile, else the env var named by api_base_env.
+# Fields whose value the yaml may name indirectly, through a sibling
+# *_env key holding the name of the environment variable to read. Adding
+# an entry here is how a new credential joins the pattern.
+ENV_INDIRECT_FIELDS = {
+    "api_key": "api_key_env",
+    "api_base": "api_base_env",
+}
 
-    Keeps the shipped yaml free of any deployment's gateway hostname while
-    letting both the `llm` and `cti` profiles read one env var. Whitespace
-    is stripped because normalize_openai_api_base treats a blank-but-truthy
-    string as a real URL and would turn it into the relative path "/v1".
+
+def resolve_env_indirection(cfg: dict) -> dict:
+    """Resolve a profile's *_env indirection into concrete values.
+
+    Every profile in the yaml (`llm`, `cti`, ...) shares one shape, so the
+    parent-side resolver in app/config.py and the provenance path here read
+    credentials through this single function rather than each rolling its
+    own. Returns a copy; the caller's dict is not mutated.
+
+    The *_env keys are consumed so they never reach the settings dict handed
+    to DSPy. Values are stripped because normalize_openai_api_base treats a
+    blank-but-truthy string as a real URL and would turn it into the
+    relative path "/v1".
+
+    Credentials come back as empty strings when neither yaml nor env supplies
+    one; the caller decides whether that is fatal.
     """
-    configured = str((llm_cfg or {}).get("api_base") or "").strip()
-    if configured:
-        return configured
-    env_var = (llm_cfg or {}).get("api_base_env")
-    return os.environ.get(env_var, "").strip() if env_var else ""
+    resolved = dict(cfg or {})
+    for field, env_key in ENV_INDIRECT_FIELDS.items():
+        env_var = resolved.pop(env_key, None)
+        value = str(resolved.get(field) or "").strip()
+        if not value and env_var:
+            value = os.environ.get(env_var, "").strip()
+        resolved[field] = value
+    # `or` rather than setdefault: yaml may carry an explicit null, which
+    # setdefault would leave in place. dspy_env.py coerces the same way, and
+    # a None here would skip every `provider == "openai_compatible"` branch.
+    resolved["provider"] = resolved.get("provider") or "openai_compatible"
+    if resolved["provider"] == "openai_compatible":
+        resolved["api_base"] = normalize_openai_api_base(resolved["api_base"]) or ""
+    return resolved
 
 
 def _aiohttp_ssl_arg(ssl_verify):
@@ -138,11 +164,10 @@ def get_llm_provenance(profile: str = "llm", *, runtime: bool = False) -> dict:
     If runtime=True, include runtime fields required to execute (api_key, api_base).
     Keep runtime=False as safe-to-log (no secrets).
     """
-    cfg = load_config()
-    llm = cfg.get(profile, {}) or {}
+    llm = resolve_env_indirection(load_config().get(profile, {}) or {})
 
     base = {
-        "provider": llm.get("provider", "openai_compatible"),
+        "provider": llm["provider"],
         "model": llm.get("model"),
         "offline": llm.get("offline", False),
         "use_mock": llm.get("use_mock", False),
@@ -158,11 +183,11 @@ def get_llm_provenance(profile: str = "llm", *, runtime: bool = False) -> dict:
     if not runtime:
         return base
 
-    # Runtime-only fields (do NOT log these)
-    base["api_key"] = llm.get("api_key")
-    base["api_base"] = resolve_api_base(llm)
-    if base["provider"] == "openai_compatible":
-        base["api_base"] = normalize_openai_api_base(base["api_base"])
+    # Runtime-only fields (do NOT log these). resolve_env_indirection has
+    # already applied the env fallback and normalized an openai_compatible
+    # base, so these are the values that will actually reach the provider.
+    base["api_key"] = llm["api_key"]
+    base["api_base"] = llm["api_base"]
 
     if not base["api_key"]:
         raise ValueError(f"{profile}.api_key missing from MCP config")
@@ -204,24 +229,25 @@ class LLMClient:
         self.cfg = load_config()
 
     async def generate(self, prompt: str, profile: str = "llm") -> str | None:
-        llm_cfg = self.cfg.get(profile, {})
-        if not llm_cfg:
+        raw_cfg = self.cfg.get(profile, {})
+        if not raw_cfg:
             raise KeyError(f"No LLM profile '{profile}' in config")
 
-        # Deterministic early exit
-        if llm_cfg.get("offline") or llm_cfg.get("use_mock"):
+        # Deterministic early exit, before any credential resolution: an
+        # offline profile is allowed to carry no key and no base at all.
+        if raw_cfg.get("offline") or raw_cfg.get("use_mock"):
             return None
 
+        llm_cfg = resolve_env_indirection(raw_cfg)
         model = llm_cfg.get("model")
-        api_base = resolve_api_base(llm_cfg)
+        api_base = llm_cfg["api_base"]
         temperature = llm_cfg.get("temperature", 0.0)
 
         if not model or not api_base:
             raise ValueError("LLM config missing model or api_base")
 
-        provider = llm_cfg.get("provider", "openai_compatible")
+        provider = llm_cfg["provider"]
         if provider == "openai_compatible":
-            api_base = normalize_openai_api_base(api_base)
             apply_litellm_ssl_verify(llm_cfg.get("ssl_verify"))
 
         if provider == "ollama":
@@ -273,17 +299,7 @@ class LLMClient:
         temperature: float,
         llm_cfg: dict,
     ) -> str | None:
-        # Resolve api_key with env-var fallback: load_config() returns the
-        # raw YAML which only carries `api_key_env`; the env-var resolution
-        # happens in plugins.mcp.app.config.llm_defaults but the LLMClient
-        # path bypasses that. Without this fallback the Authorization header
-        # comes back as "Bearer " (empty) and the upstream gateway returns
-        # 401 "Malformed API Key".
         api_key = llm_cfg.get("api_key") or ""
-        if not api_key:
-            env_var = llm_cfg.get("api_key_env") or ""
-            if env_var:
-                api_key = os.environ.get(env_var, "") or ""
         headers = {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {api_key}",

--- a/app/utilities/llm_client.py
+++ b/app/utilities/llm_client.py
@@ -183,9 +183,8 @@ def get_llm_provenance(profile: str = "llm", *, runtime: bool = False) -> dict:
     if not runtime:
         return base
 
-    # Runtime-only fields (do NOT log these). resolve_env_indirection has
-    # already applied the env fallback and normalized an openai_compatible
-    # base, so these are the values that will actually reach the provider.
+    # Runtime-only fields (do NOT log these). Already env-resolved and
+    # normalized above, so these are what reach the provider.
     base["api_key"] = llm["api_key"]
     base["api_base"] = llm["api_base"]
 
@@ -233,8 +232,8 @@ class LLMClient:
         if not raw_cfg:
             raise KeyError(f"No LLM profile '{profile}' in config")
 
-        # Deterministic early exit, before any credential resolution: an
-        # offline profile is allowed to carry no key and no base at all.
+        # Deterministic early exit, before credential resolution: an
+        # offline profile may legitimately carry no key and no base.
         if raw_cfg.get("offline") or raw_cfg.get("use_mock"):
             return None
 

--- a/app/utilities/llm_client.py
+++ b/app/utilities/llm_client.py
@@ -101,12 +101,12 @@ def normalize_openai_api_base(api_base: str | None) -> str | None:
     return urlunsplit((parts.scheme, parts.netloc, path, parts.query, parts.fragment))
 
 
-# Fields whose value the yaml may name indirectly, through a sibling
-# *_env key holding the name of the environment variable to read. Adding
-# an entry here is how a new credential joins the pattern.
+# field -> (sibling yaml key naming an env var, env_wins). Secrets resolve
+# env-first so rotating .env takes effect without editing tracked yaml;
+# endpoints resolve yaml-first so a deployment can pin one on disk.
 ENV_INDIRECT_FIELDS = {
-    "api_key": "api_key_env",
-    "api_base": "api_base_env",
+    "api_key": ("api_key_env", True),
+    "api_base": ("api_base_env", False),
 }
 
 
@@ -127,12 +127,11 @@ def resolve_env_indirection(cfg: dict) -> dict:
     one; the caller decides whether that is fatal.
     """
     resolved = dict(cfg or {})
-    for field, env_key in ENV_INDIRECT_FIELDS.items():
+    for field, (env_key, env_wins) in ENV_INDIRECT_FIELDS.items():
         env_var = resolved.pop(env_key, None)
-        value = str(resolved.get(field) or "").strip()
-        if not value and env_var:
-            value = os.environ.get(env_var, "").strip()
-        resolved[field] = value
+        yaml_value = str(resolved.get(field) or "").strip()
+        env_value = os.environ.get(env_var, "").strip() if env_var else ""
+        resolved[field] = env_value if (env_wins and env_var) else (yaml_value or env_value)
     # `or` rather than setdefault: yaml may carry an explicit null, which
     # setdefault would leave in place. dspy_env.py coerces the same way, and
     # a None here would skip every `provider == "openai_compatible"` branch.

--- a/app/workflows/author.py
+++ b/app/workflows/author.py
@@ -51,9 +51,24 @@ def get_env(lm_settings=None):
 
     return env
 
-mlflow.set_tracking_uri(mlflow_settings()['tracking_uri'])
-mlflow.set_experiment("caldera-mcp-FACTORY-client-1")
-mlflow.dspy.autolog()
+_MLFLOW_READY = False
+
+
+def _ensure_mlflow():
+    """set_experiment is a network call, so it cannot run at import time.
+
+    Doing it at module scope made importing this module block whenever the
+    tracking server was down, which put every workflow out of reach of a
+    test, a linter, or anything running before the server comes up.
+    """
+    global _MLFLOW_READY
+    if _MLFLOW_READY:
+        return
+    mlflow.set_tracking_uri(mlflow_settings()['tracking_uri'])
+    mlflow.set_experiment("caldera-mcp-FACTORY-client-1")
+    mlflow.dspy.autolog()
+    _MLFLOW_READY = True
+
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -160,6 +175,7 @@ async def run(adversary_emulation_task: str, lm_obj=None, rag_context=None, run_
     # + UI overrides, with fields_locked enforced). Workflows trust it; they
     # do not re-merge yaml here. Tests that call run() directly without
     # lm_obj fall back to the same yaml-resolved defaults.
+    _ensure_mlflow()
     lm_settings = dict(lm_obj) if lm_obj else llm_defaults()
     max_tool_calls = lm_settings.get("max_tool_calls") or 5
 

--- a/app/workflows/author.py
+++ b/app/workflows/author.py
@@ -51,23 +51,26 @@ def get_env(lm_settings=None):
 
     return env
 
-_MLFLOW_READY = False
+# set_tracking_uri and autolog are local state and stay eager. autolog must:
+# it calls dspy.settings.configure, which pins ownership to the first asyncio
+# task that reaches it, so deferring it into run() breaks the second workflow.
+mlflow.set_tracking_uri(mlflow_settings()['tracking_uri'])
+mlflow.dspy.autolog()
+
+_MLFLOW_EXPERIMENT_SET = False
 
 
 def _ensure_mlflow():
-    """set_experiment is a network call, so it cannot run at import time.
+    """set_experiment is the network call, so it cannot run at import time.
 
-    Doing it at module scope made importing this module block whenever the
-    tracking server was down, which put every workflow out of reach of a
-    test, a linter, or anything running before the server comes up.
+    At module scope it made importing this module block whenever the tracking
+    server was down, which silently dropped both workflows from the registry.
     """
-    global _MLFLOW_READY
-    if _MLFLOW_READY:
+    global _MLFLOW_EXPERIMENT_SET
+    if _MLFLOW_EXPERIMENT_SET:
         return
-    mlflow.set_tracking_uri(mlflow_settings()['tracking_uri'])
     mlflow.set_experiment("caldera-mcp-FACTORY-client-1")
-    mlflow.dspy.autolog()
-    _MLFLOW_READY = True
+    _MLFLOW_EXPERIMENT_SET = True
 
 
 current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/app/workflows/author.py
+++ b/app/workflows/author.py
@@ -163,9 +163,13 @@ async def run(adversary_emulation_task: str, lm_obj=None, rag_context=None, run_
     lm_settings = dict(lm_obj) if lm_obj else llm_defaults()
     max_tool_calls = lm_settings.get("max_tool_calls") or 5
 
-    # Validate API key is provided
-    if not lm_settings.get("api_key"):
-        error_msg = "API key is required but not provided. Please set your API key in the Global Model Configuration."
+    # Both credentials are checked here rather than at dspy.LM() so the
+    # failure lands before the AsyncExitStack spawns MCP subprocesses.
+    missing = next(
+        (f for f in ("api_key", "api_base") if not lm_settings.get(f)), None
+    )
+    if missing:
+        error_msg = f"{missing} is required but not provided. Please set it in the Global Model Configuration."
         print(f"[MCP] ERROR: {error_msg}")
         if not run_id:
             run = mlflow.start_run(run_name="MCP Ability Factory")

--- a/app/workflows/plan_execute.py
+++ b/app/workflows/plan_execute.py
@@ -86,9 +86,25 @@ def get_env(lm_settings=None):
 
     return env
 
-mlflow.set_tracking_uri(mlflow_settings()['tracking_uri'])
-mlflow.set_experiment("caldera-mcp-client-1")
-mlflow.dspy.autolog()
+_MLFLOW_READY = False
+
+
+def _ensure_mlflow():
+    """set_experiment is a network call, so it cannot run at import time.
+
+    Doing it at module scope made importing this module block whenever the
+    tracking server was down, which put every workflow out of reach of a
+    test, a linter, or anything running before the server comes up.
+    """
+    global _MLFLOW_READY
+    if _MLFLOW_READY:
+        return
+    mlflow.set_tracking_uri(mlflow_settings()['tracking_uri'])
+    mlflow.set_experiment("caldera-mcp-client-1")
+    mlflow.dspy.autolog()
+    _MLFLOW_READY = True
+
+
 current_dir = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -144,6 +160,7 @@ async def run(adversary_emulation_task: str, lm_obj=None, rag_context=None,
       - None, to fall back to llm_defaults() from the shared config module
         (used by tests / direct invocation)
     """
+    _ensure_mlflow()
     if isinstance(lm_obj, dspy.LM):
         lm_instance = lm_obj
         lm_settings = None

--- a/app/workflows/plan_execute.py
+++ b/app/workflows/plan_execute.py
@@ -86,23 +86,26 @@ def get_env(lm_settings=None):
 
     return env
 
-_MLFLOW_READY = False
+# set_tracking_uri and autolog are local state and stay eager. autolog must:
+# it calls dspy.settings.configure, which pins ownership to the first asyncio
+# task that reaches it, so deferring it into run() breaks the second workflow.
+mlflow.set_tracking_uri(mlflow_settings()['tracking_uri'])
+mlflow.dspy.autolog()
+
+_MLFLOW_EXPERIMENT_SET = False
 
 
 def _ensure_mlflow():
-    """set_experiment is a network call, so it cannot run at import time.
+    """set_experiment is the network call, so it cannot run at import time.
 
-    Doing it at module scope made importing this module block whenever the
-    tracking server was down, which put every workflow out of reach of a
-    test, a linter, or anything running before the server comes up.
+    At module scope it made importing this module block whenever the tracking
+    server was down, which silently dropped both workflows from the registry.
     """
-    global _MLFLOW_READY
-    if _MLFLOW_READY:
+    global _MLFLOW_EXPERIMENT_SET
+    if _MLFLOW_EXPERIMENT_SET:
         return
-    mlflow.set_tracking_uri(mlflow_settings()['tracking_uri'])
     mlflow.set_experiment("caldera-mcp-client-1")
-    mlflow.dspy.autolog()
-    _MLFLOW_READY = True
+    _MLFLOW_EXPERIMENT_SET = True
 
 
 current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -4,11 +4,19 @@
 # runtime via the env var named in api_key_env (set in plugins/mcp/.env)
 # or per-session through the UI's Global Model Configuration.
 #
+# api_base ships empty so no deployment's gateway hostname is baked into
+# the repo. Point it at your OpenAI-compatible endpoint via the env var
+# named in api_base_env, or pin it here in conf/local.yml. Leaving it
+# unresolved is fatal by design: LiteLLM would otherwise fall back to
+# its built-in https://api.openai.com/v1 and quietly send prompts to a
+# provider the deployment never chose.
+#
 # fields_locked declares which fields the deployment fixes; locked fields
 # ignore UI overrides and the UI greys out the corresponding inputs.
 llm:
   model: openai/gpt-oss-120b
-  api_base: https://models.k8s.aip.mitre.org/v1
+  api_base: ""
+  api_base_env: MCP_LLM_API_BASE
   api_key_env: MCP_LLM_API_KEY
   ssl_verify: true
   offline: true
@@ -22,7 +30,8 @@ llm:
 cti:
   provider: openai_compatible
   model: openai/gpt-oss-120b
-  api_base: https://models.k8s.aip.mitre.org/v1
+  api_base: ""
+  api_base_env: MCP_LLM_API_BASE
   api_key_env: MCP_LLM_API_KEY
   ssl_verify: true
   temperature: 0.0

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -6,10 +6,15 @@
 #
 # api_base ships empty so no deployment's gateway hostname is baked into
 # the repo. Point it at your OpenAI-compatible endpoint via the env var
-# named in api_base_env, or pin it here in conf/local.yml. Leaving it
-# unresolved is fatal by design: LiteLLM would otherwise fall back to
-# its built-in https://api.openai.com/v1 and quietly send prompts to a
-# provider the deployment never chose.
+# named in api_base_env. Leaving it unresolved is fatal by design:
+# LiteLLM would otherwise fall back to its built-in
+# https://api.openai.com/v1 and quietly send prompts to a provider the
+# deployment never chose.
+#
+# To pin values on disk instead, copy this whole file to conf/local.yml
+# and edit that. local.yml REPLACES this file rather than merging with
+# it, so a partial local.yml silently drops the keys it omits, including
+# the api_key_env and api_base_env indirection above.
 #
 # fields_locked declares which fields the deployment fixes; locked fields
 # ignore UI overrides and the UI greys out the corresponding inputs.

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -11,10 +11,8 @@
 # https://api.openai.com/v1 and quietly send prompts to a provider the
 # deployment never chose.
 #
-# To pin values on disk instead, copy this whole file to conf/local.yml
-# and edit that. local.yml REPLACES this file rather than merging with
-# it, so a partial local.yml silently drops the keys it omits, including
-# the api_key_env and api_base_env indirection above.
+# To pin values on disk instead, set them in conf/local.yml. That file is
+# overlaid onto this one key by key, so it only needs the keys it changes.
 #
 # fields_locked declares which fields the deployment fixes; locked fields
 # ignore UI overrides and the UI greys out the corresponding inputs.

--- a/gui/components/modelSelector.vue
+++ b/gui/components/modelSelector.vue
@@ -192,7 +192,7 @@ async function save() {
         provider: local.provider,
         model: local.model,
         api_base: local.api_base,
-        api_key: local.api_key,
+        // api_key is deliberately absent: set_config refuses to persist it.
         temperature: local.temperature,
         top_p: local.top_p,
         max_tokens: local.max_tokens,

--- a/gui/views/mcp.vue
+++ b/gui/views/mcp.vue
@@ -541,10 +541,25 @@ const availableServers = ref([])
 
 const LOCAL_STORAGE_KEY = 'mcp_global_config'
 
+// localStorage is readable by anything on this origin, so the key lives in
+// memory for the session only. Stripping at the storage boundary covers the
+// global config and every saved endpoint profile in one place.
+function stripSecrets(config) {
+  const { apiKey, ...rest } = config || {}
+  if (Array.isArray(rest.endpointProfiles)) {
+    rest.endpointProfiles = rest.endpointProfiles.map(({ apiKey: _drop, ...p }) => p)
+  }
+  return rest
+}
+
 function loadConfig() {
   try {
     const saved = localStorage.getItem(LOCAL_STORAGE_KEY)
-    if (saved) return JSON.parse(saved)
+    if (!saved) return null
+    const cleaned = JSON.stringify(stripSecrets(JSON.parse(saved)))
+    // Purge a key an earlier build persisted instead of waiting for a write.
+    if (cleaned !== saved) localStorage.setItem(LOCAL_STORAGE_KEY, cleaned)
+    return JSON.parse(cleaned)
   } catch (e) {
     console.warn('[MCP] Failed to load saved config:', e)
   }
@@ -553,7 +568,7 @@ function loadConfig() {
 
 function saveConfig(config) {
   try {
-    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(config))
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(stripSecrets(config)))
   } catch (e) {
     console.warn('[MCP] Failed to save config:', e)
   }

--- a/gui/views/mcp.vue
+++ b/gui/views/mcp.vue
@@ -546,15 +546,21 @@ const LOCAL_STORAGE_KEY = 'mcp_global_config'
 // an endpoint the deployment no longer configures.
 const CONFIG_SCHEMA_VERSION = 2
 
-// localStorage is readable by anything on this origin, so the key lives in
-// memory for the session only. Stripping at the storage boundary covers the
-// global config and every saved endpoint profile in one place.
-function stripSecrets(config) {
-  const { apiKey, ...rest } = config || {}
-  if (Array.isArray(rest.endpointProfiles)) {
-    rest.endpointProfiles = rest.endpointProfiles.map(({ apiKey: _drop, ...p }) => p)
+// localStorage is readable by anything on this origin, so keys live in memory
+// for the session only. Matched by name at any depth: a fixed list missed
+// embed_api_key and plan_api_key nested under capabilitySettings.
+const SECRET_KEY_NAME = /api_?key/i
+
+function stripSecrets(value) {
+  if (Array.isArray(value)) return value.map(stripSecrets)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([k]) => !SECRET_KEY_NAME.test(k))
+        .map(([k, v]) => [k, stripSecrets(v)]),
+    )
   }
-  return rest
+  return value
 }
 
 // Named endpoint profiles keep their apiBase: those are explicit user

--- a/gui/views/mcp.vue
+++ b/gui/views/mcp.vue
@@ -540,6 +540,11 @@ const availableCapabilities = ref([])
 const availableServers = ref([])
 
 const LOCAL_STORAGE_KEY = 'mcp_global_config'
+// Bumped when a stored field stops being safe to reuse. v2 drops a cached
+// apiBase: the endpoint moved out of the repo into MCP_LLM_API_BASE, and a
+// value saved before that outranks it on every request, silently routing to
+// an endpoint the deployment no longer configures.
+const CONFIG_SCHEMA_VERSION = 2
 
 // localStorage is readable by anything on this origin, so the key lives in
 // memory for the session only. Stripping at the storage boundary covers the
@@ -552,14 +557,23 @@ function stripSecrets(config) {
   return rest
 }
 
+// Named endpoint profiles keep their apiBase: those are explicit user
+// artifacts, applied deliberately. Only the ambient default is dropped.
+function migrate(config) {
+  if (config.schemaVersion === CONFIG_SCHEMA_VERSION) return config
+  const { apiBase, ...rest } = config
+  return { ...rest, schemaVersion: CONFIG_SCHEMA_VERSION }
+}
+
 function loadConfig() {
   try {
     const saved = localStorage.getItem(LOCAL_STORAGE_KEY)
     if (!saved) return null
-    const cleaned = JSON.stringify(stripSecrets(JSON.parse(saved)))
-    // Purge a key an earlier build persisted instead of waiting for a write.
+    const parsed = migrate(stripSecrets(JSON.parse(saved)))
+    const cleaned = JSON.stringify(parsed)
+    // Rewrite now rather than waiting for the next save.
     if (cleaned !== saved) localStorage.setItem(LOCAL_STORAGE_KEY, cleaned)
-    return JSON.parse(cleaned)
+    return parsed
   } catch (e) {
     console.warn('[MCP] Failed to load saved config:', e)
   }
@@ -568,7 +582,10 @@ function loadConfig() {
 
 function saveConfig(config) {
   try {
-    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(stripSecrets(config)))
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify({
+      ...stripSecrets(config),
+      schemaVersion: CONFIG_SCHEMA_VERSION,
+    }))
   } catch (e) {
     console.warn('[MCP] Failed to save config:', e)
   }

--- a/templates/mcp.html
+++ b/templates/mcp.html
@@ -15,11 +15,13 @@
                     {% if llm_configured %}
                         <span class="tag is-success is-light">configured</span>
                         &nbsp;model <code>{{ llm_model }}</code>
-                        {% if llm_api_base %}&middot; base <code>{{ llm_api_base }}</code>{% endif %}
+                        &middot; base <code>{{ llm_api_base }}</code>
                     {% else %}
-                        <span class="tag is-warning is-light">no key</span>
-                        &nbsp;set <code>{{ llm_api_key_env }}</code> in <code>plugins/mcp/.env</code>
-                        or enter one per-session in the workspace's Global Model Configuration.
+                        <span class="tag is-warning is-light">incomplete</span>
+                        &nbsp;set
+                        {% for env_var in llm_missing_env %}<code>{{ env_var }}</code>{% if not loop.last %} and {% endif %}{% endfor %}
+                        in <code>plugins/mcp/.env</code>, or supply the missing
+                        values per-session in the workspace's Global Model Configuration.
                     {% endif %}
                 </li>
                 <li class="mt-2">
@@ -59,10 +61,12 @@
             {% if not llm_configured %}
             <article class="message is-warning mt-4">
                 <div class="message-body">
-                    The plugin will still load, but every workflow run will fail with
-                    "No LLM API key" until either <code>MCP_LLM_API_KEY</code> is
-                    set in the .env or a key is supplied via the workspace's
-                    Global Model Configuration panel.
+                    The plugin will still load, but every workflow run will fail
+                    until
+                    {% for env_var in llm_missing_env %}<code>{{ env_var }}</code>{% if not loop.last %} and {% endif %}{% endfor %}
+                    {% if llm_missing_env | length > 1 %}are{% else %}is{% endif %}
+                    set in the .env, or the missing values are supplied via the
+                    workspace's Global Model Configuration panel.
                 </div>
             </article>
             {% endif %}

--- a/tests/test_author_guards.py
+++ b/tests/test_author_guards.py
@@ -1,0 +1,38 @@
+"""author.run() must reject incomplete credentials before spawning servers.
+
+The check sits above the AsyncExitStack, so a missing value fails fast
+instead of after every MCP stdio subprocess has already been started.
+"""
+import pytest
+
+
+@pytest.fixture
+def offline_mlflow(tmp_path, monkeypatch):
+    """Local sqlite store; the error path logs to MLflow before it raises."""
+    import mlflow
+    from plugins.mcp.app.workflows import author
+
+    monkeypatch.setattr(author, "_ensure_mlflow", lambda: None)
+    mlflow.set_tracking_uri(f"sqlite:///{tmp_path}/mlflow.db")
+    mlflow.set_experiment("test-author-guards")
+    yield
+    if mlflow.active_run():
+        mlflow.end_run()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("missing,lm_obj", [
+    ("api_base", {"api_key": "sk-test", "model": "openai/x"}),
+    ("api_key", {"api_base": "https://gw/v1", "model": "openai/x"}),
+])
+async def test_rejects_incomplete_credentials(offline_mlflow, missing, lm_obj, monkeypatch):
+    from plugins.mcp.app.workflows import author
+
+    # Fails loudly if the guard ever moves below the exit stack.
+    def _no_spawn(*args, **kwargs):
+        raise AssertionError("spawned a subprocess before validating credentials")
+
+    monkeypatch.setattr(author, "stdio_client", _no_spawn, raising=False)
+
+    with pytest.raises(ValueError, match=missing):
+        await author.run("test", lm_obj=lm_obj, server_registry={}, enabled_servers=[])

--- a/tests/test_author_guards.py
+++ b/tests/test_author_guards.py
@@ -36,3 +36,24 @@ async def test_rejects_incomplete_credentials(offline_mlflow, missing, lm_obj, m
 
     with pytest.raises(ValueError, match=missing):
         await author.run("test", lm_obj=lm_obj, server_registry={}, enabled_servers=[])
+
+
+@pytest.mark.asyncio
+async def test_both_workflows_configure_from_separate_tasks(tmp_path):
+    """mcp_svc runs each /execute in its own task.
+
+    mlflow.dspy.autolog calls dspy.settings.configure, which pins ownership to
+    the first asyncio task to reach it. Deferring it into run() therefore broke
+    whichever workflow ran second, permanently, for the life of the process.
+    """
+    import asyncio
+    import mlflow
+    from plugins.mcp.app.workflows import author, plan_execute
+
+    mlflow.set_tracking_uri(f"sqlite:///{tmp_path}/mlflow.db")
+    for module in (author, plan_execute):
+        await asyncio.create_task(_configure(module))
+
+
+async def _configure(module):
+    module._ensure_mlflow()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -220,3 +220,64 @@ class TestDspyLmKwargs:
             dspy_lm_kwargs_from_settings(
                 {"model": "openai/x", "api_key": "k", "provider": "ollama"}
             )
+
+
+class TestProvenanceGuards:
+    """get_llm_provenance is the third resolver; same invariant applies."""
+
+    @pytest.fixture
+    def stub_yaml(self, monkeypatch):
+        from plugins.mcp.app.utilities import llm_client
+        cfg = {"cti": {"model": "openai/x", "api_key": "sk-test", "api_base": ""}}
+        monkeypatch.setattr(llm_client, "load_config", lambda: cfg)
+        return cfg
+
+    def test_safe_payload_never_carries_credentials(self, stub_yaml):
+        from plugins.mcp.app.utilities.llm_client import get_llm_provenance
+        base = get_llm_provenance("cti")
+        assert "api_key" not in base and "api_base" not in base
+
+    def test_runtime_requires_api_base(self, stub_yaml):
+        from plugins.mcp.app.utilities.llm_client import get_llm_provenance
+        with pytest.raises(ValueError, match="api_base missing"):
+            get_llm_provenance("cti", runtime=True)
+
+    @pytest.mark.parametrize("provider", ["ollama", "azure"])
+    def test_runtime_requires_api_base_for_every_provider(self, stub_yaml, provider):
+        # This guard used to be gated on openai_compatible, unlike the other two.
+        from plugins.mcp.app.utilities.llm_client import get_llm_provenance
+        stub_yaml["cti"]["provider"] = provider
+        with pytest.raises(ValueError, match="api_base missing"):
+            get_llm_provenance("cti", runtime=True)
+
+
+class TestReadinessPayload:
+    """The splash page must not report configured while a run would fail."""
+
+    def _context(self, monkeypatch, api_key, api_base):
+        from plugins.mcp.app import mcp_gui
+        monkeypatch.setattr(
+            mcp_gui, "llm_defaults",
+            lambda: {"api_key": api_key, "api_base": api_base, "model": "openai/x"},
+        )
+        monkeypatch.setattr(mcp_gui, "caldera_connection", dict)
+        gui = mcp_gui.McpGUI({}, "mcp", "desc")
+        return gui._bootstrap_context()
+
+    def test_configured_needs_both(self, monkeypatch):
+        ctx = self._context(monkeypatch, "sk-test", "https://gw/v1")
+        assert ctx["llm_configured"] is True
+        assert ctx["llm_missing_env"] == []
+
+    def test_api_key_alone_is_not_configured(self, monkeypatch):
+        ctx = self._context(monkeypatch, "sk-test", "")
+        assert ctx["llm_configured"] is False
+        assert ctx["llm_missing_env"] == ["MCP_LLM_API_BASE"]
+
+    def test_names_every_missing_variable(self, monkeypatch):
+        ctx = self._context(monkeypatch, "", "")
+        assert ctx["llm_missing_env"] == ["MCP_LLM_API_KEY", "MCP_LLM_API_BASE"]
+
+    def test_payload_never_carries_the_key(self, monkeypatch):
+        ctx = self._context(monkeypatch, "sk-secret", "https://gw/v1")
+        assert "sk-secret" not in str(ctx)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,7 @@
-"""Tests for config.py and dspy_env.py: LLM profile resolution and its guards.
+"""Tests for LLM profile resolution and the api_base guards.
 
-Covers the three tiers resolve_llm_config merges (yaml, env, UI override)
-and the two refusals that keep an unresolved endpoint from reaching
-LiteLLM, which would otherwise fall back to https://api.openai.com/v1.
-
-_load_defaults is stubbed throughout so these never read conf/default.yml
-and never depend on the developer's own .env.
+_load_defaults is stubbed throughout, so these read neither
+conf/default.yml nor the developer's .env.
 """
 import pytest
 
@@ -83,8 +79,8 @@ class TestResolveEnvIndirection:
         assert cfg["api_base_env"] == "MCP_LLM_API_BASE"
 
     def test_explicit_null_provider_is_coerced(self):
-        # setdefault left a yaml `provider:` null in place, and every
-        # `provider == "openai_compatible"` branch then silently skipped.
+        # setdefault left a yaml `provider:` null in place, silently
+        # skipping every `provider == "openai_compatible"` branch.
         from plugins.mcp.app.utilities.llm_client import resolve_env_indirection
         resolved = resolve_env_indirection({"provider": None, "api_base": "https://h"})
         assert resolved["provider"] == "openai_compatible"
@@ -135,8 +131,7 @@ class TestResolveLlmConfig:
     @pytest.mark.parametrize("provider", ["ollama", "azure", "wat", None])
     def test_api_base_required_for_every_provider(self, yaml_defaults, provider):
         # The guard used to sit inside `if provider == "openai_compatible"`,
-        # so naming any other provider skipped it while model stayed
-        # openai/*, which is exactly the routing the guard exists to block.
+        # so naming any other provider skipped it while model stayed openai/*.
         from plugins.mcp.app.config import resolve_llm_config
         with pytest.raises(ValueError, match="No LLM api_base"):
             resolve_llm_config({"provider": provider})
@@ -148,8 +143,7 @@ class TestResolveLlmConfig:
         assert merged["api_base"] == "https://ui.example.com/v1"
 
     def test_whitespace_override_falls_back_to_default(self, yaml_defaults, monkeypatch):
-        # "   " is truthy and normalizes to "/v1", which satisfied the guard
-        # and failed later inside the HTTP client instead of here.
+        # "   " is truthy and normalizes to "/v1", satisfying the guard.
         from plugins.mcp.app.config import resolve_llm_config
         monkeypatch.setenv("MCP_LLM_API_BASE", "https://env.example.com")
         merged = resolve_llm_config({"api_base": "   "})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -281,3 +281,48 @@ class TestReadinessPayload:
     def test_payload_never_carries_the_key(self, monkeypatch):
         ctx = self._context(monkeypatch, "sk-secret", "https://gw/v1")
         assert "sk-secret" not in str(ctx)
+
+
+class TestLocalYmlMerge:
+    """A partial local.yml must not drop the env wiring from default.yml."""
+
+    def _write(self, tmp_path, name, data):
+        import yaml
+        conf = tmp_path / "conf"
+        conf.mkdir(exist_ok=True)
+        (conf / name).write_text(yaml.safe_dump(data))
+
+    @pytest.fixture
+    def loader(self, tmp_path, monkeypatch):
+        from plugins.mcp.app.utilities import llm_client
+        monkeypatch.setattr(llm_client, "get_mcp_root", lambda: tmp_path)
+        llm_client.load_config.cache_clear()
+        yield llm_client.load_config
+        llm_client.load_config.cache_clear()
+
+    def test_local_overlays_rather_than_replaces(self, tmp_path, loader):
+        # What the UI's Save writes: no api_key_env, no api_base_env.
+        self._write(tmp_path, "default.yml", {
+            "llm": {"model": "openai/gpt-oss-120b", "api_key_env": "MCP_LLM_API_KEY"},
+            "caldera": {"url_env": "CALDERA_URL"},
+        })
+        self._write(tmp_path, "local.yml", {"llm": {"model": "devstral"}})
+        cfg = loader()
+        assert cfg["llm"]["model"] == "devstral"
+        assert cfg["llm"]["api_key_env"] == "MCP_LLM_API_KEY"
+        assert cfg["caldera"]["url_env"] == "CALDERA_URL"
+
+    def test_unknown_local_sections_do_not_hide_defaults(self, tmp_path, loader):
+        # A caller once posted {"config": {...}}, which replaced the whole file.
+        self._write(tmp_path, "default.yml", {"llm": {"model": "m"}})
+        self._write(tmp_path, "local.yml", {"config": {"cti": {"model": "junk"}}})
+        cfg = loader()
+        assert cfg["llm"]["model"] == "m"
+
+    def test_default_only_still_loads(self, tmp_path, loader):
+        self._write(tmp_path, "default.yml", {"llm": {"model": "m"}})
+        assert loader()["llm"]["model"] == "m"
+
+    def test_missing_both_raises(self, tmp_path, loader):
+        with pytest.raises(FileNotFoundError):
+            loader()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,6 +56,30 @@ class TestResolveEnvIndirection:
         )
         assert resolved["api_base"] == "https://pinned.example.com/v1"
 
+    def test_api_key_resolves_env_first(self, monkeypatch):
+        # Secrets invert the api_base rule: a yaml literal must not shadow the
+        # env var, or rotating .env silently does nothing.
+        from plugins.mcp.app.utilities.llm_client import resolve_env_indirection
+        monkeypatch.setenv("MCP_LLM_API_KEY", "sk-env")
+        resolved = resolve_env_indirection(
+            {"api_key": "sk-yaml", "api_key_env": "MCP_LLM_API_KEY"}
+        )
+        assert resolved["api_key"] == "sk-env"
+
+    def test_api_key_falls_back_to_yaml_when_no_env_var_named(self):
+        from plugins.mcp.app.utilities.llm_client import resolve_env_indirection
+        assert resolve_env_indirection({"api_key": "sk-yaml"})["api_key"] == "sk-yaml"
+
+    def test_strips_whitespace_from_yaml(self, monkeypatch):
+        # Only the env side was covered; an unstripped yaml "   " normalizes
+        # to the truthy relative path "/v1" and satisfies every guard.
+        from plugins.mcp.app.utilities.llm_client import resolve_env_indirection
+        monkeypatch.delenv("MCP_LLM_API_BASE", raising=False)
+        resolved = resolve_env_indirection(
+            {"api_base": "   ", "api_base_env": "MCP_LLM_API_BASE"}
+        )
+        assert resolved["api_base"] == ""
+
     def test_strips_whitespace_from_env(self, monkeypatch):
         # An unstripped blank is truthy and normalizes to the relative "/v1".
         from plugins.mcp.app.utilities.llm_client import resolve_env_indirection

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,204 @@
+"""Tests for config.py and dspy_env.py: LLM profile resolution and its guards.
+
+Covers the three tiers resolve_llm_config merges (yaml, env, UI override)
+and the two refusals that keep an unresolved endpoint from reaching
+LiteLLM, which would otherwise fall back to https://api.openai.com/v1.
+
+_load_defaults is stubbed throughout so these never read conf/default.yml
+and never depend on the developer's own .env.
+"""
+import pytest
+
+
+BASE_YAML = {
+    "llm": {
+        "model": "openai/gpt-oss-120b",
+        "api_base": "",
+        "api_base_env": "MCP_LLM_API_BASE",
+        "api_key_env": "MCP_LLM_API_KEY",
+        "provider": "openai_compatible",
+    },
+    "cti": {
+        "model": "openai/gpt-oss-120b",
+        "api_base": "",
+        "api_base_env": "MCP_LLM_API_BASE",
+        "api_key_env": "MCP_LLM_API_KEY",
+        "provider": "openai_compatible",
+    },
+}
+
+
+@pytest.fixture
+def yaml_defaults(monkeypatch):
+    """Stub the yaml loader; yields the dict so a test can reshape it."""
+    from plugins.mcp.app import config
+
+    cfg = {key: dict(value) for key, value in BASE_YAML.items()}
+    monkeypatch.setattr(config, "_load_defaults", lambda: cfg)
+    monkeypatch.delenv("MCP_LLM_API_BASE", raising=False)
+    monkeypatch.setenv("MCP_LLM_API_KEY", "sk-test")
+    return cfg
+
+
+class TestResolveEnvIndirection:
+    """The one resolver both config.py and the provenance path call."""
+
+    def test_reads_env_var_named_by_api_base_env(self, monkeypatch):
+        from plugins.mcp.app.utilities.llm_client import resolve_env_indirection
+        monkeypatch.setenv("MCP_LLM_API_BASE", "https://gw.example.com")
+        resolved = resolve_env_indirection(
+            {"api_base": "", "api_base_env": "MCP_LLM_API_BASE"}
+        )
+        assert resolved["api_base"] == "https://gw.example.com/v1"
+
+    def test_yaml_value_outranks_env(self, monkeypatch):
+        from plugins.mcp.app.utilities.llm_client import resolve_env_indirection
+        monkeypatch.setenv("MCP_LLM_API_BASE", "https://env.example.com")
+        resolved = resolve_env_indirection(
+            {"api_base": "https://pinned.example.com/v1",
+             "api_base_env": "MCP_LLM_API_BASE"}
+        )
+        assert resolved["api_base"] == "https://pinned.example.com/v1"
+
+    def test_strips_whitespace_from_env(self, monkeypatch):
+        # An unstripped blank is truthy and normalizes to the relative "/v1".
+        from plugins.mcp.app.utilities.llm_client import resolve_env_indirection
+        monkeypatch.setenv("MCP_LLM_API_BASE", "   ")
+        resolved = resolve_env_indirection(
+            {"api_base": "", "api_base_env": "MCP_LLM_API_BASE"}
+        )
+        assert resolved["api_base"] == ""
+
+    def test_consumes_env_keys(self, monkeypatch):
+        from plugins.mcp.app.utilities.llm_client import resolve_env_indirection
+        monkeypatch.setenv("MCP_LLM_API_KEY", "sk-test")
+        resolved = resolve_env_indirection(dict(BASE_YAML["llm"]))
+        assert "api_base_env" not in resolved
+        assert "api_key_env" not in resolved
+
+    def test_does_not_mutate_caller(self, monkeypatch):
+        from plugins.mcp.app.utilities.llm_client import resolve_env_indirection
+        cfg = dict(BASE_YAML["llm"])
+        resolve_env_indirection(cfg)
+        assert cfg["api_base_env"] == "MCP_LLM_API_BASE"
+
+    def test_explicit_null_provider_is_coerced(self):
+        # setdefault left a yaml `provider:` null in place, and every
+        # `provider == "openai_compatible"` branch then silently skipped.
+        from plugins.mcp.app.utilities.llm_client import resolve_env_indirection
+        resolved = resolve_env_indirection({"provider": None, "api_base": "https://h"})
+        assert resolved["provider"] == "openai_compatible"
+
+
+class TestProfileDefaults:
+    """Both yaml profiles resolve through the same code."""
+
+    def test_unset_env_yields_empty_base(self, yaml_defaults):
+        from plugins.mcp.app.config import profile_defaults
+        assert profile_defaults("llm")["api_base"] == ""
+
+    def test_llm_and_cti_resolve_identically(self, yaml_defaults, monkeypatch):
+        from plugins.mcp.app.config import profile_defaults
+        monkeypatch.setenv("MCP_LLM_API_BASE", "https://gw.example.com")
+        assert (
+            profile_defaults("llm")["api_base"]
+            == profile_defaults("cti")["api_base"]
+            == "https://gw.example.com/v1"
+        )
+
+    def test_cti_may_name_its_own_env_var(self, yaml_defaults, monkeypatch):
+        from plugins.mcp.app.config import profile_defaults
+        yaml_defaults["cti"]["api_base_env"] = "MCP_CTI_API_BASE"
+        monkeypatch.setenv("MCP_LLM_API_BASE", "https://shared.example.com")
+        monkeypatch.setenv("MCP_CTI_API_BASE", "https://cti.example.com")
+        assert profile_defaults("cti")["api_base"] == "https://cti.example.com/v1"
+        assert profile_defaults("llm")["api_base"] == "https://shared.example.com/v1"
+
+    def test_llm_defaults_is_the_llm_profile(self, yaml_defaults):
+        from plugins.mcp.app.config import llm_defaults, profile_defaults
+        assert llm_defaults() == profile_defaults("llm")
+
+
+class TestResolveLlmConfig:
+    def test_raises_without_api_base(self, yaml_defaults):
+        from plugins.mcp.app.config import resolve_llm_config
+        with pytest.raises(ValueError, match="No LLM api_base"):
+            resolve_llm_config({})
+
+    def test_raises_without_api_key(self, yaml_defaults, monkeypatch):
+        from plugins.mcp.app.config import resolve_llm_config
+        monkeypatch.setenv("MCP_LLM_API_BASE", "https://gw.example.com")
+        monkeypatch.setenv("MCP_LLM_API_KEY", "")
+        with pytest.raises(ValueError, match="No LLM API key"):
+            resolve_llm_config({})
+
+    @pytest.mark.parametrize("provider", ["ollama", "azure", "wat", None])
+    def test_api_base_required_for_every_provider(self, yaml_defaults, provider):
+        # The guard used to sit inside `if provider == "openai_compatible"`,
+        # so naming any other provider skipped it while model stayed
+        # openai/*, which is exactly the routing the guard exists to block.
+        from plugins.mcp.app.config import resolve_llm_config
+        with pytest.raises(ValueError, match="No LLM api_base"):
+            resolve_llm_config({"provider": provider})
+
+    def test_ui_override_outranks_env(self, yaml_defaults, monkeypatch):
+        from plugins.mcp.app.config import resolve_llm_config
+        monkeypatch.setenv("MCP_LLM_API_BASE", "https://env.example.com")
+        merged = resolve_llm_config({"api_base": "https://ui.example.com"})
+        assert merged["api_base"] == "https://ui.example.com/v1"
+
+    def test_whitespace_override_falls_back_to_default(self, yaml_defaults, monkeypatch):
+        # "   " is truthy and normalizes to "/v1", which satisfied the guard
+        # and failed later inside the HTTP client instead of here.
+        from plugins.mcp.app.config import resolve_llm_config
+        monkeypatch.setenv("MCP_LLM_API_BASE", "https://env.example.com")
+        merged = resolve_llm_config({"api_base": "   "})
+        assert merged["api_base"] == "https://env.example.com/v1"
+
+    def test_trailing_space_is_trimmed_not_appended(self, yaml_defaults, monkeypatch):
+        from plugins.mcp.app.config import resolve_llm_config
+        monkeypatch.setenv("MCP_LLM_API_BASE", "https://env.example.com")
+        merged = resolve_llm_config({"api_base": "https://ui.example.com/v1 "})
+        assert merged["api_base"] == "https://ui.example.com/v1"
+
+    def test_locked_fields_ignore_overrides(self, yaml_defaults, monkeypatch):
+        from plugins.mcp.app.config import resolve_llm_config
+        yaml_defaults["llm"]["fields_locked"] = {"api_base": True}
+        monkeypatch.setenv("MCP_LLM_API_BASE", "https://env.example.com")
+        merged = resolve_llm_config({"api_base": "https://ui.example.com"})
+        assert merged["api_base"] == "https://env.example.com/v1"
+
+    def test_env_keys_never_reach_the_settings_dict(self, yaml_defaults, monkeypatch):
+        from plugins.mcp.app.config import resolve_llm_config
+        monkeypatch.setenv("MCP_LLM_API_BASE", "https://gw.example.com")
+        merged = resolve_llm_config({})
+        assert "api_base_env" not in merged
+        assert "api_key_env" not in merged
+
+
+class TestDspyLmKwargs:
+    """The backstop every dspy.LM() in the plugin passes through."""
+
+    def test_builds_kwargs_when_resolved(self):
+        from plugins.mcp.app.dspy_env import dspy_lm_kwargs_from_settings
+        kwargs = dspy_lm_kwargs_from_settings(
+            {"model": "openai/x", "api_key": "k", "api_base": "https://gw/v1"}
+        )
+        assert kwargs["api_base"] == "https://gw/v1"
+        assert kwargs["custom_llm_provider"] == "custom_openai"
+
+    @pytest.mark.parametrize("api_base", ["", "   ", None])
+    def test_refuses_to_build_without_api_base(self, api_base):
+        # Dropping the falsy base is what let LiteLLM apply its own default.
+        from plugins.mcp.app.dspy_env import dspy_lm_kwargs_from_settings
+        with pytest.raises(ValueError, match="no api_base"):
+            dspy_lm_kwargs_from_settings(
+                {"model": "openai/x", "api_key": "k", "api_base": api_base}
+            )
+
+    def test_refuses_for_non_openai_providers_too(self):
+        from plugins.mcp.app.dspy_env import dspy_lm_kwargs_from_settings
+        with pytest.raises(ValueError, match="no api_base"):
+            dspy_lm_kwargs_from_settings(
+                {"model": "openai/x", "api_key": "k", "provider": "ollama"}
+            )

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -25,14 +25,14 @@ class TestGetLlmProvenance:
 class TestNormalizeOpenAiApiBase:
     def test_appends_v1(self):
         from plugins.mcp.app.utilities.llm_client import normalize_openai_api_base
-        assert normalize_openai_api_base("https://models.k8s.aip.mitre.org") == (
-            "https://models.k8s.aip.mitre.org/v1"
+        assert normalize_openai_api_base("https://llm.example.com") == (
+            "https://llm.example.com/v1"
         )
 
     def test_preserves_existing_v1(self):
         from plugins.mcp.app.utilities.llm_client import normalize_openai_api_base
-        assert normalize_openai_api_base("https://models.k8s.aip.mitre.org/v1") == (
-            "https://models.k8s.aip.mitre.org/v1"
+        assert normalize_openai_api_base("https://llm.example.com/v1") == (
+            "https://llm.example.com/v1"
         )
 
 

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -3,7 +3,7 @@ Tests for LLM model configuration — modelSelector.vue backend.
 
 Tests different LLM backend configurations:
 - Ollama (local)
-- OpenAI-compatible (MITRE AIP, OpenAI, etc.)
+- OpenAI-compatible (any OpenAI-compatible gateway)
 - Offline mode (no LLM)
 - Config validation (required fields)
 - Config persistence
@@ -99,7 +99,7 @@ class TestOllamaConfig:
 
 @skip
 class TestOpenAICompatibleConfig:
-    """Test OpenAI-compatible backend (MITRE AIP, OpenAI, etc.)."""
+    """Test OpenAI-compatible backend (any OpenAI-compatible gateway)."""
 
     def test_set_openai_compatible_config(self):
         """Set config to use OpenAI-compatible backend."""
@@ -118,7 +118,7 @@ class TestOpenAICompatibleConfig:
                     "offline": False,
                     "use_mock": False,
                     "ssl_verify": False,
-                    "extra_headers": {"Host": "models.k8s.aip.mitre.org"},
+                    "extra_headers": {"Host": "llm.example.com"},
                 }
             }
         }
@@ -243,7 +243,7 @@ class TestRestoreConfig:
                     "offline": False,
                     "use_mock": False,
                     "ssl_verify": False,
-                    "extra_headers": {"Host": "models.k8s.aip.mitre.org"},
+                    "extra_headers": {"Host": "llm.example.com"},
                 }
             }
         }

--- a/tests/test_set_config_secrets.py
+++ b/tests/test_set_config_secrets.py
@@ -86,3 +86,29 @@ async def test_strips_secrets_inside_lists(api, tmp_path):
         "llm": {"profiles": [{"name": "a", "api_key": "sk-in-list"}]},
     }))
     assert "sk-in-list" not in (tmp_path / "conf" / "local.yml").read_text()
+
+
+@pytest.mark.asyncio
+async def test_strips_every_key_field_the_ui_uses(api, tmp_path):
+    # A fixed list kept missing new ones as the RAG panels grew.
+    await api.set_config(_FakeRequest({
+        "llm": {"api_key": "sk-a", "embed_api_key": "sk-b", "plan_api_key": "sk-c",
+                "rag_api_key": "sk-d", "cti_rag_api_key": "sk-e", "apiKey": "sk-f",
+                "model": "keep-me"},
+    }))
+    text = (tmp_path / "conf" / "local.yml").read_text()
+    for leaked in ("sk-a", "sk-b", "sk-c", "sk-d", "sk-e", "sk-f"):
+        assert leaked not in text
+    assert _saved(tmp_path)["llm"] == {"model": "keep-me"}
+
+
+@pytest.mark.asyncio
+async def test_keeps_the_env_var_indirection(api, tmp_path):
+    # api_key_env names a variable, not a value. Dropping it would silently
+    # disable .env resolution for the whole deployment.
+    await api.set_config(_FakeRequest({
+        "llm": {"api_key_env": "MCP_LLM_API_KEY", "api_base_env": "MCP_LLM_API_BASE"},
+    }))
+    assert _saved(tmp_path)["llm"] == {
+        "api_key_env": "MCP_LLM_API_KEY", "api_base_env": "MCP_LLM_API_BASE",
+    }

--- a/tests/test_set_config_secrets.py
+++ b/tests/test_set_config_secrets.py
@@ -65,3 +65,24 @@ async def test_save_scrubs_a_key_an_earlier_build_wrote(api, tmp_path):
     assert "sk-legacy" not in text
     assert "api_key" not in text
     assert _saved(tmp_path)["cti"]["model"] == "old"
+
+
+@pytest.mark.asyncio
+async def test_strips_nested_secrets(api, tmp_path):
+    # set_config accepts arbitrary top-level keys, so callers have produced
+    # nested shapes like {"config": {"cti": {...}}}. A one-level scrub
+    # walked straight past those.
+    await api.set_config(_FakeRequest({
+        "config": {"cti": {"model": "m", "api_key": "sk-nested"}},
+    }))
+    text = (tmp_path / "conf" / "local.yml").read_text()
+    assert "sk-nested" not in text
+    assert _saved(tmp_path)["config"]["cti"] == {"model": "m"}
+
+
+@pytest.mark.asyncio
+async def test_strips_secrets_inside_lists(api, tmp_path):
+    await api.set_config(_FakeRequest({
+        "llm": {"profiles": [{"name": "a", "api_key": "sk-in-list"}]},
+    }))
+    assert "sk-in-list" not in (tmp_path / "conf" / "local.yml").read_text()

--- a/tests/test_set_config_secrets.py
+++ b/tests/test_set_config_secrets.py
@@ -1,0 +1,67 @@
+"""conf/local.yml must never receive a credential.
+
+set_config is the plugin's own Save endpoint and the UI posts api_key with
+every save, so the filter lives server-side where a stale browser cannot
+bypass it.
+"""
+import pytest
+import yaml
+
+
+class _FakeRequest:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+
+@pytest.fixture
+def api(tmp_path, monkeypatch):
+    from plugins.mcp.app import mcp_api
+
+    monkeypatch.setattr(mcp_api, "get_mcp_root", lambda: tmp_path)
+    monkeypatch.setattr(mcp_api, "get_mcp_data_dir", lambda: tmp_path / "data")
+    monkeypatch.setattr(mcp_api, "reload_config", dict)
+    return mcp_api.McpAPI({"mcp_svc": None})
+
+
+def _saved(tmp_path):
+    return yaml.safe_load((tmp_path / "conf" / "local.yml").read_text())
+
+
+@pytest.mark.asyncio
+async def test_api_key_is_not_written(api, tmp_path):
+    await api.set_config(_FakeRequest({
+        "llm": {"model": "openai/x", "api_base": "https://gw/v1", "api_key": "sk-secret"}
+    }))
+    saved = _saved(tmp_path)
+    assert "api_key" not in saved["llm"]
+    assert "sk-secret" not in (tmp_path / "conf" / "local.yml").read_text()
+    assert saved["llm"]["api_base"] == "https://gw/v1"
+
+
+@pytest.mark.asyncio
+async def test_every_secret_field_is_stripped(api, tmp_path):
+    await api.set_config(_FakeRequest({
+        "llm": {"api_key": "a", "embed_api_key": "b", "rag_api_key": "c", "model": "m"}
+    }))
+    assert _saved(tmp_path)["llm"] == {"model": "m"}
+
+
+@pytest.mark.asyncio
+async def test_save_scrubs_a_key_an_earlier_build_wrote(api, tmp_path):
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    (conf / "local.yml").write_text(yaml.safe_dump({
+        "llm": {"model": "old", "api_key": "sk-legacy"},
+        "cti": {"model": "old", "api_key": "sk-legacy-cti"},
+    }))
+
+    # Saving an unrelated section still cleans the whole file.
+    await api.set_config(_FakeRequest({"llm": {"model": "new"}}))
+
+    text = (conf / "local.yml").read_text()
+    assert "sk-legacy" not in text
+    assert "api_key" not in text
+    assert _saved(tmp_path)["cti"]["model"] == "old"


### PR DESCRIPTION
## Description

Consolidates LLM credential resolution into one implementation, and removes the vendor gateway hostname from the repo.

**Before:** `config.py::llm_defaults` was hardcoded to the yaml `llm` block while `llm_client.py::get_llm_provenance` took a profile argument. Each had its own copy of the `api_key_env` lookup, and `LLMClient._openai_compatible_generate` carried a third with a comment saying it existed only because that path bypassed `config.py`.

**After:** one resolver, `llm_client.resolve_env_indirection`, with three call sites. `config.py` exposes `profile_defaults(profile)` and keeps `llm_defaults()` as a thin alias, so the `cti` profile resolves through exactly the same code as `llm`.

### Resolution order

| Tier | Source | Wins when |
|---|---|---|
| 1 | `conf/default.yml`, overlaid by `conf/local.yml` | the floor |
| 2 | `.env` via the `*_env` keys | see below |
| 3 | UI Global Model Configuration, per request | always, unless `fields_locked` |

Secrets and endpoints deliberately differ at tier 2. `api_key` resolves **env first**, so rotating `.env` takes effect without editing a tracked file. `api_base` resolves **yaml first**, so a deployment can pin an endpoint on disk. Both are declared in `ENV_INDIRECT_FIELDS`.

### Refusing to guess an endpoint

`conf/default.yml` shipped `api_base: https://models.k8s.aip.mitre.org/v1` for both profiles. Both now ship empty and name `MCP_LLM_API_BASE`.

An unresolved `api_base` is refused rather than passed through. `dspy_lm_kwargs_from_settings` dropped a falsy `api_base` entirely, which left LiteLLM routing `openai/*` models to its built in `https://api.openai.com/v1`, sending the prompt and the deployment's key to a provider nobody chose. The guard sits at `dspy_lm_kwargs_from_settings`, which is the one place all four `dspy.LM()` construction sites pass through, with a friendlier check earlier in `resolve_llm_config`.

### No credential in plaintext

Three surfaces closed:

- `conf/local.yml`: `set_config` posted `api_key` verbatim. Secrets are now stripped from the whole file on every write, so a save also scrubs a key an earlier build left behind.
- Browser `localStorage`: `globalConfig` and every saved endpoint profile were serialized as is. Stripped at the storage boundary, and load purges what is already stored.
- Both filters match `/api_?key/i` by name at any depth rather than listing fields, because the enumerated lists had already fallen behind the UI and were missing `embed_api_key`, `plan_api_key` and `cti_rag_api_key`. `api_key_env` is kept: it names a variable, not a value.

### Also fixed, found while verifying the above

- `conf/local.yml` replaced `conf/default.yml` wholesale, so any partial file dropped the `*_env` wiring and silently disabled `.env` resolution. It is now overlaid key by key. This mattered once secrets were stripped: a UI save produced a file with neither a key nor the wiring to find one.
- A `localStorage` `apiBase` cached before the vendor URL was removed outranked `MCP_LLM_API_BASE` on every request. The stored blob is now versioned and a pre v2 blob drops the ambient `apiBase`. Named endpoint profiles keep theirs, since those are explicit user artifacts.
- The splash page reported `configured` from `api_key` alone, which stopped being a complete precondition. It now names the specific variables that failed to resolve.
- `author.py` and `plan_execute.py` called `mlflow.set_experiment` at module scope. That is a network round trip, so importing either module blocked whenever the tracking server was down, and `discover_workflows` swallowed the exception and dropped both workflows from the registry. Only `set_experiment` is deferred: `dspy.autolog` stays eager because it pins `dspy.settings` to the first asyncio task that reaches it, and each `/execute` runs in its own task.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Upgrade note

Existing deployments must add `MCP_LLM_API_BASE` to `plugins/mcp/.env`. `.env.example` never carried that line, so every existing `.env` has only `MCP_LLM_API_KEY` and the first run after this change will fail with an actionable error naming the variable.

## How Has This Been Tested?

`75 passed` across `test_config.py`, `test_set_config_secrets.py`, `test_author_guards.py` and `test_llm_client.py`. Three of those files are new (49 cases).

Every guard was mutation tested rather than assumed. Reverting each fix fails exactly the tests that should catch it:

| Mutation | Fails |
|---|---|
| re-nest the api_base guard under `openai_compatible` | 3 `test_api_base_required_for_every_provider` cases |
| disable the `dspy_env` guard | 4 `TestDspyLmKwargs` refusal cases |
| drop the yaml side strip | `test_strips_whitespace_from_yaml` |
| revert the secret filter to a fixed list | `test_strips_every_key_field_the_ui_uses` |
| make the secret scrub non-recursive | `test_strips_nested_secrets`, `test_strips_secrets_inside_lists` |
| restore replace-not-merge in `load_config` | 2 `TestLocalYmlMerge` cases |
| defer `dspy.autolog` again | `test_both_workflows_configure_from_separate_tasks` |

Resolution was also traced end to end against a live endpoint. One `.env` pair in, identical values out of all four consumers:

```
resolve_llm_config  [Author/PlanExec]  base=.../v1  key=set  resolver=YES
llm_defaults        [direct run]       base=.../v1  key=set  resolver=YES
profile_defaults('cti')                base=.../v1  key=set  resolver=YES
get_llm_provenance('cti', runtime)     base=.../v1  key=set  resolver=YES
```

flake8 with the repo config shows **no new violations**: every changed file matches its violation count on `main`, and the three new test files are clean. `flake8 . --select=E9,F63,F7`, the CI hard gate, passes.

### Pre-existing test failures, not caused by this branch

Reviewers running the whole directory will hit these on `main` too:

- `test_relation_extractor.py:19` imports `cti_relation_extractor`, which does not exist (the module is `cti_relationships.py`), aborting collection for the directory.
- `test_range_integration.py` needs `plugins/range/mcp_server.py`, which is not vendored here.
- `test_model_config.py::TestConfigStructure::test_cti_has_toggle_fields` requires a `stream` field that the `cti` block has never had.

`test_model_config.py` also POSTs `{"config": {...}}` at a live server, and `set_config` stores arbitrary top level keys verbatim, so running it corrupts `conf/local.yml`. Harmless now that `local.yml` is overlaid rather than substituted, but worth its own fix.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
