### PR TITLE
fix(mlflow): mint each run in its own workflow's experiment

### DIFF
--- a/app/mcp_svc.py
+++ b/app/mcp_svc.py
@@ -373,18 +373,21 @@ class MCPService(BaseService):
         # below uses `mlflow.start_run(run_id=...)` in its own context
         # manager, which is per-task and doesn't conflict.
         from mlflow.tracking import MlflowClient as _Mlc
-        # The workflow module creates this on its first run(), which is after
-        # this lookup, so mint it here rather than filing the run under
-        # Default. create_experiment not set_experiment: the latter would
-        # mutate the process-wide active experiment this block avoids.
-        _exp = mlflow.get_experiment_by_name("caldera-mcp-client-1")
+        # Mint into the workflow's own experiment. Hardcoding one name here
+        # broke every run after the first: mlflow.start_run(run_id=...) raises
+        # when the process-wide active experiment differs from the run's, and
+        # a workflow that set_experiment a different name flipped it.
+        # create_experiment not set_experiment: the latter would mutate the
+        # process-wide active experiment this block avoids.
+        _exp_name = workflow.mlflow_experiment
+        _exp = mlflow.get_experiment_by_name(_exp_name)
         if _exp is not None:
             _exp_id = _exp.experiment_id
         else:
             try:
-                _exp_id = _Mlc().create_experiment("caldera-mcp-client-1")
+                _exp_id = _Mlc().create_experiment(_exp_name)
             except Exception:
-                _exp = mlflow.get_experiment_by_name("caldera-mcp-client-1")
+                _exp = mlflow.get_experiment_by_name(_exp_name)
                 _exp_id = _exp.experiment_id if _exp else "0"
         run = _Mlc().create_run(
             experiment_id=_exp_id,

--- a/app/workflows/author.py
+++ b/app/workflows/author.py
@@ -57,6 +57,7 @@ def get_env(lm_settings=None):
 mlflow.set_tracking_uri(mlflow_settings()['tracking_uri'])
 mlflow.dspy.autolog()
 
+_MLFLOW_EXPERIMENT = "caldera-mcp-FACTORY-client-1"
 _MLFLOW_EXPERIMENT_SET = False
 
 
@@ -69,7 +70,7 @@ def _ensure_mlflow():
     global _MLFLOW_EXPERIMENT_SET
     if _MLFLOW_EXPERIMENT_SET:
         return
-    mlflow.set_experiment("caldera-mcp-FACTORY-client-1")
+    mlflow.set_experiment(_MLFLOW_EXPERIMENT)
     _MLFLOW_EXPERIMENT_SET = True
 
 
@@ -359,6 +360,7 @@ WORKFLOWS = [
         required_servers=["caldera_core"],
         optional_servers=[],
         accepted_capabilities=["rag"],
+        mlflow_experiment=_MLFLOW_EXPERIMENT,
         ui_component="author.vue",
         example_prompts=[
             "Create a few abilities related to persistence with WMI for Windows, then create an adversary with those abilities. Please create more than one ability.",

--- a/app/workflows/base.py
+++ b/app/workflows/base.py
@@ -51,6 +51,11 @@ class Workflow:
     # capability's enrich() when its id appears here AND the user enabled it.
     accepted_capabilities: list[str] = field(default_factory=list)
 
+    # MLflow experiment this workflow's runs belong to. mcp_svc mints the run
+    # here, and the workflow must set_experiment the same name: mlflow refuses
+    # start_run(run_id=...) when the active experiment differs from the run's.
+    mlflow_experiment: str = "caldera-mcp-client-1"
+
     # Optional plan-then-execute mode. When set, the orchestrator treats the
     # signature's structured output as a plan, hands it to the dotted-path
     # validate function for validation/binding, and executes whatever tool

--- a/app/workflows/plan_execute.py
+++ b/app/workflows/plan_execute.py
@@ -92,6 +92,7 @@ def get_env(lm_settings=None):
 mlflow.set_tracking_uri(mlflow_settings()['tracking_uri'])
 mlflow.dspy.autolog()
 
+_MLFLOW_EXPERIMENT = "caldera-mcp-client-1"
 _MLFLOW_EXPERIMENT_SET = False
 
 
@@ -104,7 +105,7 @@ def _ensure_mlflow():
     global _MLFLOW_EXPERIMENT_SET
     if _MLFLOW_EXPERIMENT_SET:
         return
-    mlflow.set_experiment("caldera-mcp-client-1")
+    mlflow.set_experiment(_MLFLOW_EXPERIMENT)
     _MLFLOW_EXPERIMENT_SET = True
 
 
@@ -380,6 +381,7 @@ WORKFLOWS = [
         required_servers=["caldera_core"],
         optional_servers=["cti_pipeline", "range"],
         accepted_capabilities=["rag"],
+        mlflow_experiment=_MLFLOW_EXPERIMENT,
         ui_component="plan_execute.vue",
         example_prompts=PLAN_EXECUTE_EXAMPLES,
         run=run,

--- a/tests/test_mlflow_experiment_binding.py
+++ b/tests/test_mlflow_experiment_binding.py
@@ -1,0 +1,69 @@
+"""Run/experiment binding for mlflow.start_run(run_id=...).
+
+mlflow refuses to resume a run when the process-wide active experiment
+differs from the run's. Two workflows using different experiment names
+therefore broke every execution after the first.
+"""
+import mlflow
+import pytest
+
+from plugins.mcp.app.workflows.author import WORKFLOWS as AUTHOR_WORKFLOWS
+from plugins.mcp.app.workflows.plan_execute import WORKFLOWS as PLAN_WORKFLOWS
+
+
+@pytest.fixture
+def tracking(tmp_path):
+    mlflow.set_tracking_uri(f"sqlite:///{tmp_path}/mlflow.db")
+    yield
+    if mlflow.active_run():
+        mlflow.end_run()
+
+
+def test_every_workflow_declares_an_experiment():
+    for wf in list(AUTHOR_WORKFLOWS) + list(PLAN_WORKFLOWS):
+        assert wf.mlflow_experiment, f"{wf.id} has no experiment"
+
+
+def test_author_and_plan_execute_do_not_share_an_experiment():
+    """They are deliberately separate; the bug was mcp_svc ignoring that."""
+    author = AUTHOR_WORKFLOWS[0].mlflow_experiment
+    plan = PLAN_WORKFLOWS[0].mlflow_experiment
+    assert author != plan
+
+
+@pytest.mark.parametrize("wf", list(AUTHOR_WORKFLOWS) + list(PLAN_WORKFLOWS),
+                         ids=lambda w: w.id)
+def test_run_minted_in_the_workflow_experiment_can_be_resumed(tracking, wf):
+    """Reproduces the failure: mint where the workflow says, activate the
+    same name, resume. Before the fix mcp_svc always minted into
+    caldera-mcp-client-1, so the author case raised here."""
+    from mlflow.tracking import MlflowClient
+
+    client = MlflowClient()
+    exp = mlflow.get_experiment_by_name(wf.mlflow_experiment)
+    exp_id = exp.experiment_id if exp else client.create_experiment(wf.mlflow_experiment)
+    run_id = client.create_run(experiment_id=exp_id).info.run_id
+
+    # What the workflow does on its first run().
+    mlflow.set_experiment(wf.mlflow_experiment)
+
+    mlflow.end_run()
+    with mlflow.start_run(run_id=run_id):
+        mlflow.set_tag("stage", "initializing")
+
+
+def test_mismatched_experiment_is_what_raises(tracking):
+    """Pins the mechanism, so a future refactor that reintroduces a
+    hardcoded name fails here rather than in production."""
+    from mlflow.tracking import MlflowClient
+
+    client = MlflowClient()
+    minted_in = client.create_experiment("minted-here")
+    run_id = client.create_run(experiment_id=minted_in).info.run_id
+
+    mlflow.set_experiment("active-elsewhere")
+
+    mlflow.end_run()
+    with pytest.raises(Exception, match="does not match"):
+        with mlflow.start_run(run_id=run_id):
+            pass


### PR DESCRIPTION
Every execution after the first failed with:

```
Cannot start run with ID <id> because active experiment ID does not match
environment run ID.
```

## Cause

`mcp_svc` minted every run into `caldera-mcp-client-1` regardless of which
workflow was executing:

```python
_exp = mlflow.get_experiment_by_name("caldera-mcp-client-1")
```

But `author` sets the process-wide active experiment to a different name,
`caldera-mcp-FACTORY-client-1`. MLflow refuses to resume a run whose experiment
differs from the active one (`mlflow/tracking/fluent.py`):

```python
if (_active_experiment_id is not None
        and _active_experiment_id != active_run_obj.info.experiment_id):
    raise MlflowException(f"Cannot start run with ID {existing_run_id} ...")
```

So once an author run had switched the active experiment, every later
`mlflow.start_run(run_id=...)` raised.

## Why it appeared to work once

Deferring `set_experiment` out of import time exposed it rather than causing it.
The first request runs before the switch and matches, so the failure starts on
the second request. Before the deferral both workflow modules called
`set_experiment` at import and whichever imported last won, which happened to
match the hardcoded name.

## Fix

`Workflow` declares its experiment and `mcp_svc` mints there, so there is one
source of truth per workflow. The two experiments stay deliberately separate.

```python
mlflow_experiment: str = "caldera-mcp-client-1"
```

## Tests

`tests/test_mlflow_experiment_binding.py` covers the binding, including a test
that pins the MLflow mechanism itself so a future refactor reintroducing a
hardcoded name fails here rather than in production.

Verified the tests catch the regression: reverting the fix gives `1 failed,
4 passed`, restoring it gives `5 passed`.

Baseline on `main` is 51 passed across `test_author_guards`, `test_config` and
`test_set_config_secrets`; this branch is 56 with the 5 added. No regressions.

Tests need CALDERA core importable:

```bash
PYTHONPATH=<caldera-root> python -m pytest plugins/mcp/tests/test_mlflow_experiment_binding.py -v
```