### PR TITLE
fix(mcp): default the CTI Pipeline tool server to off

### DIFF
--- a/app/discovery/servers.py
+++ b/app/discovery/servers.py
@@ -57,7 +57,7 @@ def discover_mcp_servers(plugins_root: Path) -> dict:
     if cti_pipeline_path.exists():
         cti_metadata = _safe_load_metadata(cti_pipeline_path) or {
             "display_name": "CTI Pipeline",
-            "default_enabled": True,
+            "default_enabled": False,
             "description": (
                 "CTI ingest -> STIX -> adversary -> "
                 "-> operation -> detection-validation tools."

--- a/app/workflows/plan_execute.py
+++ b/app/workflows/plan_execute.py
@@ -188,11 +188,9 @@ async def run(adversary_emulation_task: str, lm_obj=None, rag_context=None,
 
     # Resolve which MCP servers to spawn
     if not enabled_servers:
-        # Default to both caldera_core and cti_pipeline so the planner has
-        # the full CTI -> STIX -> deploy -> operation -> detections toolset
-        # out of the box. cti_pipeline is filtered out below if its server
-        # file is missing (graceful fall-back to caldera_core-only mode).
-        enabled_servers = ["caldera_core", "cti_pipeline"]
+        # Default to caldera_core only. cti_pipeline is opt-in: the GUI ticks
+        # it on when STIX is selected, and callers can pass it explicitly.
+        enabled_servers = ["caldera_core"]
     if server_registry is None:
         # Fallback used only when run() is invoked without a registry (e.g. tests).
         # mcp_server.py lives one directory up after the workflows/ split.
@@ -210,7 +208,7 @@ async def run(adversary_emulation_task: str, lm_obj=None, rag_context=None,
                 "path": cti_pipeline_server_path,
                 "metadata": {
                     "display_name": "CTI Pipeline",
-                    "default_enabled": True,
+                    "default_enabled": False,
                     "description": (
                         "CTI ingest -> STIX -> adversary -> "
                         "deploy -> operation -> detection-validation tools."

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -111,7 +111,7 @@ from mcp.server.fastmcp import FastMCP
 MCP_METADATA = {
     "id": "cti_pipeline",
     "display_name": "CTI Pipeline",
-    "default_enabled": True,
+    "default_enabled": False,
     "description": (
         "End-to-end CTI ingest tools: PDF/HTML -> STIX 2.1 bundle -> "
         "adversary -> operation "


### PR DESCRIPTION
## Description

The CTI Pipeline MCP tool server was registered with `default_enabled: True`, so every new Plan and Execute session started with its checkbox ticked. That spawned the pipeline subprocess and merged its tools into the planner's toolset even on runs that never touched CTI.

It is now opt-in. `MCP_METADATA` in `mcp_server.py` declares `default_enabled: False`, and the two fallback registries that mirror that metadata (`app/discovery/servers.py`, `app/workflows/plan_execute.py`) match. The GUI seeds each workflow's default toggles from `default_enabled`, so the sidebar checkbox now starts unchecked; `caldera_core` stays on as the required server.

Nothing else about the server changes. It is still discovered, still listed under MCP Tool Servers, and the chat view still turns it on automatically when STIX files are selected for a Plan and Execute run. Saved per-workflow selections are untouched, so anyone who already had it ticked keeps it.

`plan_execute.run()` with no `enabled_servers` now defaults to `["caldera_core"]` instead of `["caldera_core", "cti_pipeline"]`, matching what the GUI sends.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `pytest tests/test_discovery_and_tool_merge.py` in a clean plugins root: both tests pass, confirming the metadata is still parsed without executing the module and that the registry keys are unchanged.
- Loaded `discover_mcp_servers` against a plugins root whose `mcp_server.py` carries no `MCP_METADATA`, exercising the hardcoded fallback: `{'caldera_core': True, 'cti_pipeline': False}`.
- Parsed `MCP_METADATA` out of `mcp_server.py` with `ast.literal_eval` the way discovery does: `cti_pipeline default_enabled = False`.
- Ran the full `tests/` suite before and after the change; the failing set is identical, all of it pre-existing and unrelated (missing optional deps and fixtures). `tests/test_relation_extractor.py` imports a module that does not exist on main and fails collection either way.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (none needed; `PLUGIN_MCP.md` already documents `default_enabled` as a per-server opt-in flag)
- [ ] I have added tests that prove my fix is effective or that my feature works (the existing discovery tests cover the metadata path; the default itself is a one-value registration)
